### PR TITLE
❌ DO NOT MERGE (bad commit history): decorative img

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ CNAME
 Icon[
 ]
 .DS_Store
+Gemfile.lock

--- a/_checklist-web/image-decorative.md
+++ b/_checklist-web/image-decorative.md
@@ -1,0 +1,90 @@
+---
+layout: entry
+title:  "Decorative image"
+description: "How to code and test accessible decorative images (jpg, gif, png, svg)"
+categories: main
+
+keyboard:
+  arrow-keys: |
+    Screenreader ignores the image completely
+
+mobile:
+  swipe: |
+    The screenreader ignores the image completely
+
+screenreader:
+  role:  |
+    The image is ignored
+
+gherkin-keyboard: 
+  - when:  |
+      the arrow keys to browse to an image
+    result: |
+      the image is skipped and ignored
+
+gherkin-mobile:
+  - when:  |
+      swipe to browse to an image
+
+wcag:
+  - name: Perceivable
+    list:
+      - criteria: All non-text content that is purely for decoration or which repeats existing on-screen text nearby should be ignored and skipped over by screenreaders.
+---
+
+## Decorative images
+
+There are times that images shouldn't be read because they would be repetitive or not add any value in addition to the existing page content. These images are generally included for purely stylistic purposes and don't have any direct meaning to the rest of the content on the page other than imparting a certain tone or feeling.
+
+## Is this image decorative or informative?
+If the image conveys important meaning, and there's no other text on the page which explains the concept within it, then the image likely is informative. See the [informative image checklist](/checklist-web/image) item instead. 
+
+If your image contains text inside it, this is a violation of [WCAG AA 1.4.5 Images of Text](https://www.w3.org/WAI/WCAG21/Understanding/images-of-text.html). Exceptions exist for logos.
+
+## The alt attribute is still required
+
+- To have valid HTML, the `alt` attribute must still be present, even when set to the empty empty value of `alt` or `alt=""` (no space in between quotations). Either is an acceptable way to set the alt attribute to empty ([source](https://www.w3.org/TR/html-aam-1.0/#el-img-empty-alt)).
+  - When the `alt` attribute is empty, the screen reader ignores it (and will not read anything).
+  - When the `alt` attribute is missing, the screen reader will read the src url or filename of the image which is a very poor user experience.
+
+## Reinforce decorative images with aria-hidden
+// Is this still true? We should test with a few screen readers and confirm. I think empty alt is very well supported by now. Additionally, I feel like adding additional aria goes against using the semantics first and foremost and actually builds in tech debt that devs may misuse.
+
+- Use `aria-hidden="true"` as a backup and reinforcement to `alt=""`:
+  - Backup: **developers often mistakenly omit the alt attribute entirely**, meaning that some screenreaders will read the entire filename without an alt attribute. Including `aria-hidden="true"` will act as a backup.
+  - Reinforcement: using `aria-hidden="true"` ensures that screenreaders ignores the image. Screenreaders have been observed reading an image role even when the alt attribute is empty.
+
+{% highlight html %}
+<img src="/info-icon.png" aria-hidden="true" alt="">
+{% endhighlight %}
+
+{% highlight html %}
+<a href="tel:8888888888">
+  <!-- The phone icon would be repetitive in this case and should be hidden -->
+  <img src="/phone-icon.png" aria-hidden="true" alt="">
+  Call us: 888-888-888
+</a>
+{% endhighlight %}
+
+
+## Using inline SVG
+
+### Inline SVG that conveys meaning
+
+Inline SVGs require some special code to be hidden properly from screen readers:
+- `aria-hidden="true"`
+
+If you are using a `<use />` element, add `aria-hidden="true"`.
+
+### Inline SVG that is decorative
+{% highlight html %}
+<svg aria-hidden="true" focusable="false">
+  <use href="#svg-id" aria-hidden="true" />
+  <!-- if not using <use> then the child elements 
+       of the inline SVG would go here -->
+</svg>
+{% endhighlight %}
+
+## Further reading
+- This page owes a lot to this exhaustive blog post: [Contextually Marking up accessible images and SVGs by Scott O'Hara](https://www.scottohara.me/blog/2019/05/22/contextual-images-svgs-and-a11y.html)
+- [W3C Image decision tree](https://www.w3.org/WAI/tutorials/images/decision-tree/)

--- a/_checklist-web/image.md
+++ b/_checklist-web/image.md
@@ -1,7 +1,7 @@
 ---
 layout: entry
-title:  "Image: jpg, gif, png, svg"
-description: "How to code and test accessible images the Web"
+title:  "Informative Image"
+description: "How to code and test accessible informative images (jpg, gif, png, svg)"
 categories: main
 
 keyboard:
@@ -34,59 +34,41 @@ wcag:
       - criteria: All non-text content that is presented to the user has a text alternative that serves the equivalent purpose, unless it is decorative or repetitive
       - criteria: If an image contains text critical to understanding the page the user has a text alternative that serves the equivalent purpose
 ---
+## Is this image decorative or informative?
+If the image conveys important meaning, and there's no other text on the page which explains the concept within it, then the image likely is informative. If the image only serves to impart a tone or feeling to the page, the image is likely decorative. See the [decorative image checklist](/checklist-web/image-decorative) item instead. 
 
-## Basic examples
+If your image contains text inside it, this is a violation of [WCAG AA 1.4.5 Images of Text](https://www.w3.org/WAI/WCAG21/Understanding/images-of-text.html). Exceptions exist for logos.
 
-### Describe the content of the image
-If you were describing the image to someone who couldn't see it, what would you say?
+## Describe the content of the image
+If you were describing the image to someone via phone conversation and they couldn't see what you were looking at, what would you say?
 
 {% highlight html %}
 <img src="/farm.jpg" 
      alt="Rustic barn surrounded by rolling hills">
 {% endhighlight %}
 
-### Linked SVG that conveys meaning
+## Linked img/SVG that conveys meaning
+If the and img or SVG is linked to another page, its purpose should be clear and a user should know where they will go when clicking it.
 
 {% highlight html %}
-<img src="/coffee-roaster.svg" 
+<a href="/coffee-roasting">
+  <img src="/coffee-roaster.svg" 
      role="img"
-     alt="Coffee roaster">
-{% endhighlight %}
-
-## Decorative images
-
-There are times that images shouldn't be read because they would be repetitive or not add any value to the content.
-
-### The alt attribute is still required
-
-- To be valid html, the `alt` attribute must still be present, even if empty
-  - When the `alt` attribute is empty, the screen reader ignores it.
-  - When the `alt` attribute is missing, the screen reader will read the src url or filename of the image.
-
-### Reinforce decorative images with aria-hidden
-
-- Use `aria-hidden="true"` as a backup and reinforcement:
-  - As a backup: **developers often mistakenly omit the alt attribute entirely**, meaning that some screenreaders will read the entire filename.
-  - As a **reinforcement** to ensure the screenreader ignores the image. Screenreaders have been observed reading an image role when the alt attribute is present but empty.
-
-{% highlight html %}
-<img src="/info-icon.png" aria-hidden="true" alt>
-{% endhighlight %}
-
-{% highlight html %}
-<a href="tel:8888888888">
-  <!-- The phone icon would be repetitive in this case and should be hidden -->
-  <img src="/phone-icon.png" aria-hidden="true" alt>
-  Call us: 888-888-888
+     alt="Learn about the coffee roasting process">
 </a>
 {% endhighlight %}
-
 
 ## Using inline SVG
 
 ### Inline SVG that conveys meaning
 
-Inline SVGs require some special code to be read consistently in all screenreaders.
+Inline SVGs require some special code to be read consistently in all screenreaders:
+- Name: either `aria-label` or `<title />`
+- Role: `role="img"`
+
+If you are using a `<use />` element, add `aria-hidden="true"` to it.
+
+#### Using title
 
 {% highlight html %}
 <svg role="img" focusable="false">
@@ -97,18 +79,13 @@ Inline SVGs require some special code to be read consistently in all screenreade
 </svg>
 {% endhighlight %}
 
-### Inline SVG `<use>` that conveys meaning
-{% highlight html %}
-<svg role="img" aria-label="Name" focusable="false">
-  <use xlink:href="#..." aria-hidden="true"></use>
-</svg>
-{% endhighlight %}
+#### Using aria-label
 
-
-### Inline SVG that is decorative
 {% highlight html %}
-<svg aria-hidden="true" focusable="false">
-  <!-- ... --> 
+<svg role="img" aria-label="Accessible name" focusable="false">
+  <use href="#svg-id" aria-hidden="true" />
+  <!-- if not using <use> then the child elements 
+       of the inline SVG would go here -->
 </svg>
 {% endhighlight %}
 
@@ -118,6 +95,6 @@ Inline SVGs require some special code to be read consistently in all screenreade
 - they are set to stop after 5 seconds or 
 - if users are presented with a way to pause it
 
-### Further reading
-
+## Further reading
 - This page owes a lot to this exhaustive blog post: [Contextually Marking up accessible images and SVGs by Scott O'Hara](https://www.scottohara.me/blog/2019/05/22/contextual-images-svgs-and-a11y.html)
+- [W3C Image decision tree](https://www.w3.org/WAI/tutorials/images/decision-tree/)

--- a/_demos/image-decorative.md
+++ b/_demos/image-decorative.md
@@ -1,0 +1,8 @@
+---
+layout: demo
+title:  "Decorative Image"
+---
+
+{::nomarkdown}
+{% include /examples/image-decorative.html %}
+{:/}

--- a/_includes/examples/image-decorative.html
+++ b/_includes/examples/image-decorative.html
@@ -1,0 +1,31 @@
+<h2>Img with empty alt</h2>
+<img src="https://images.unsplash.com/photo-1542273917363-3b1817f69a2d?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1474&q=80" alt>
+
+<ul>
+  <li>NVDA+Firefox</li>
+  <li>Voiceover+Safari: skips entirely</li>
+</ul>
+
+<h2>Img with empty alt=""</h2>
+<img src="https://images.unsplash.com/photo-1542273917363-3b1817f69a2d?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1474&q=80" alt="">
+
+<ul>
+  <li>NVDA+Firefox</li>
+  <li>Voiceover+Safari: skips entirely</li>
+</ul>
+
+<h2>Img with empty alt and aria-hidden="true"</h2>
+<img src="https://images.unsplash.com/photo-1542273917363-3b1817f69a2d?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1474&q=80" alt aria-hidden="true">
+
+<ul>
+  <li>NVDA+Firefox</li>
+  <li>Voiceover+Safari: skips entiely</li>
+</ul>
+
+<h2>Img with empty alt="" and aria-hidden="true"</h2>
+<img src="https://images.unsplash.com/photo-1542273917363-3b1817f69a2d?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1474&q=80" alt="" aria-hidden="true">
+
+<ul>
+  <li>NVDA+Firefox</li>
+  <li>Voiceover+Safari: skips entiely</li>
+</ul>


### PR DESCRIPTION
- creates 2 distinct entries for decorative vs informative img
- expands/edits some of the writing in each entry (please edit/revise as you see fit!)
- adds a demo page http://localhost:4000/demos/image-decorative/ to test out aria-hidden="true" on decorative images. Lindsay thinks alt empty alone should work in all modern and even post-modern version browsers/screen reader combos