### PR TITLE
add support windows high contrast mode - fake radios

### DIFF
--- a/_sass/modules/_input-radio.scss
+++ b/_sass/modules/_input-radio.scss
@@ -20,6 +20,15 @@ input[type="checkbox"].radio,
     }
   }
 
+  @media screen and (-ms-high-contrast: active) {
+    + label,
+    + .label {
+      &:before {
+        border: solid 2px transparent;
+      }
+    }
+  }
+
   + label:hover:before,
   &:focus + label:before {
     background: none;
@@ -47,6 +56,18 @@ input[type="checkbox"].radio,
     &:active + label:before {
       background-color: $color-brand-primary;
       box-shadow: inset 0 0 0 .25rem $color-brand-primary, inset 0 0 0rem .5rem #fff, 0 0 0rem .75rem rgba($color-focus,.4);
+    }
+  }
+  @media screen and (-ms-high-contrast: active) {
+    &:checked {
+      + label,
+      .label.fake-radio.checked {
+        &:before {
+          outline: 4px solid transparent;
+          outline-offset: -10px;
+          border: solid 2px transparent;
+        }
+      }
     }
   }
   &:disabled,

--- a/_sass/modules/_input-radio.scss
+++ b/_sass/modules/_input-radio.scss
@@ -20,7 +20,7 @@ input[type="checkbox"].radio,
     }
   }
 
-  @media screen and (-ms-high-contrast: active) {
+  @media (forced-colors: active){
     + label,
     + .label {
       &:before {
@@ -58,7 +58,7 @@ input[type="checkbox"].radio,
       box-shadow: inset 0 0 0 .25rem $color-brand-primary, inset 0 0 0rem .5rem #fff, 0 0 0rem .75rem rgba($color-focus,.4);
     }
   }
-  @media screen and (-ms-high-contrast: active) {
+  @media (forced-colors: active){
     &:checked {
       + label,
       .label.fake-radio.checked {


### PR DESCRIPTION
Hi :) Just plugging in some CSS support for fake radio buttons in High Contrast Mode.

![Screenshot of fake radio with no visual treatment in WHCM](https://user-images.githubusercontent.com/3695795/231810335-ba7fd3ee-8123-4697-b9a2-f0ab24f5d48d.png)

![Screenshot of fake radio with visual treatment in WHCM](https://user-images.githubusercontent.com/3695795/231810439-60a7100f-2bbe-4d32-b908-d4842b502826.png)
