### PR TITLE
Convert <ul> to <ol> for breadcrumbs

### DIFF
--- a/_checklist-web/breadcrumbs.md
+++ b/_checklist-web/breadcrumbs.md
@@ -83,4 +83,5 @@ wcag:
 - Breadcrumb link names must correspond to their destination page titles.
   - In the example here, the "Web" link uses an `aria-label` that corresponds to the full title of the destination page.
 - Use a `<nav>` with a unique name like `aria-label=”breadcrumbs”`
-- Placing the links inside `<ul>` and `<li>` provides context to users about a given breadcrumb’s position in a list and of the total number of breadcrumbs.
+- Placing the links inside `<ol>` and `<li>` provides context to users about a given breadcrumb’s position in a list and of the total number of breadcrumbs.
+- [ARIA Authoring Practices Guide (APG) Breadcrumb Example](https://www.w3.org/WAI/ARIA/apg/patterns/breadcrumb/examples/breadcrumb/)

--- a/_includes/examples/nav-breadcrumbs.html
+++ b/_includes/examples/nav-breadcrumbs.html
@@ -1,5 +1,5 @@
 <nav class="breadcrumbs" aria-label="Breadcrumb">
-  <ul>
+  <ol>
     <li>
       <a href="/">
         Home
@@ -17,5 +17,5 @@
         Breadcrumbs
       </a>
     </li>
-  </ul>
+  </ol>
 </nav>

--- a/_sass/modules/_nav-breadcrumbs.scss
+++ b/_sass/modules/_nav-breadcrumbs.scss
@@ -1,7 +1,7 @@
 .breadcrumbs {
   background-color: #fff;
   
-  ul {
+  ol {
     display: flex;
     margin: 0;
     padding: 1rem;


### PR DESCRIPTION
Hi team, 

- Converted `<ul>` to `<ol>` for breadcrumbs example. Semantically, an ordered list is a good fit here since order does matter.
- I've also added a link to the APG breadcrumb example, which our guidance will align with as a result of this PR :) 