### PR TITLE
Add note about scroll-padding to sticky elements page

### DIFF
--- a/_checklist-web/sticky-content.md
+++ b/_checklist-web/sticky-content.md
@@ -71,6 +71,7 @@ html { scroll-padding-top: 3rem; }
 
 <script>
   document.documentElement.style.scrollPaddingTop = "5rem";
+  document.documentElement.style.scrollPaddingBottom = "5rem";
 </script>
 
 

--- a/_checklist-web/sticky-content.md
+++ b/_checklist-web/sticky-content.md
@@ -63,5 +63,14 @@ It uses only CSS (no JavaScript) to float content as desired.
 
 - Must appear in logical page order within the page.
 - Do not place it at the actual end or beginning of the DOM
+- To ensure that controls which receive keyboard focus are not concealed by a sticky container, utilize CSS [scroll-padding](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-padding).
+
+{% highlight css %}
+html { scroll-padding-top: 3rem; }
+{% endhighlight %}
+
+<script>
+  document.documentElement.style.scrollPaddingTop = "5rem";
+</script>
 
 

--- a/_checklist-web/sticky-content.md
+++ b/_checklist-web/sticky-content.md
@@ -70,8 +70,7 @@ html { scroll-padding-top: 3rem; }
 {% endhighlight %}
 
 <script>
-  document.documentElement.style.scrollPaddingTop = "5rem";
-  document.documentElement.style.scrollPaddingBottom = "5rem";
+  document.documentElement.style.scrollPadding = "5rem 0";
 </script>
 
 

--- a/_checklist-web/sticky-content.md
+++ b/_checklist-web/sticky-content.md
@@ -63,14 +63,4 @@ It uses only CSS (no JavaScript) to float content as desired.
 
 - Must appear in logical page order within the page.
 - Do not place it at the actual end or beginning of the DOM
-- To ensure that controls which receive keyboard focus are not concealed by a sticky container, utilize CSS [scroll-padding](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-padding).
-
-{% highlight css %}
-html { scroll-padding-top: 3rem; }
-{% endhighlight %}
-
-<script>
-  document.documentElement.style.scrollPadding = "5rem 0";
-</script>
-
-
+- To ensure that controls which receive keyboard focus are not concealed by a sticky container, utilize CSS [scroll-padding](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-padding) or [scroll-margin](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-margin).


### PR DESCRIPTION
Adding a note in `Developer notes` about `scroll-padding` usage to combat controls being hidden beneath sticky containers when they receive keyboard focus (and satisfy 2.4.12: Focus Not obscured). I'm adding the CSS to this demo page `_checklist-web/sticky-content.md` w/inline JS (yucky but works). 

https://user-images.githubusercontent.com/3695795/236333240-2f1c4bac-25b8-47c2-91c3-2662e0c75aae.mp4

