### PR TITLE
fix small 2.5.3 Label in Name issue on button example

### DIFF
--- a/_checklist-web/button.md
+++ b/_checklist-web/button.md
@@ -152,7 +152,7 @@ This custom button requires extra attributes and JS event listeners. Adding `tab
   <!-- icon but no text -->
 </div>
 
-<div role="button" tabindex="0" aria-label="Add iPhone 17 to cart">
+<div role="button" tabindex="0" aria-label="Buy now, iPhone 17">
   Buy now <!-- Ambiguous text doesn't describe the intent -->
 </div>
 {% endhighlight %}


### PR DESCRIPTION
Updating to include visual text as part of `aria-label`.