### PR TITLE
Remove generic text from How To Test page

### DIFF
--- a/how-to-test.md
+++ b/how-to-test.md
@@ -4,9 +4,3 @@ title: Websites
 seoTitle: How to test accessibility
 permalink: /how-to-test/
 ---
-
-Accessibility testing is important because it helps to ensure that everyone can use a website or application, regardless of their disability. This includes people who are blind, deaf, have low vision, or have mobility impairments.
-
-To thoroughly test web accessibility, a combination of manual and automated testing methods are performed against the [Web Content Accessibility Guidelines](https://www.w3.org/TR/WCAG21/)) (WCAG) 2.1 Level A and AA. Manual testing involves people navigating the site, using assistive technologies like screen readers or keyboard-only navigation, and verifying if all content is perceivable, operable, understandable. Automated testing utilizes specialized tools to scan for common accessibility issues, such as missing alternative text for images or improper heading structure.
-
-By combining both approaches, we can identify and address accessibility barriers comprehensively, improving the overall user experience and inclusivity of our digital products.

--- a/how-to/not-sure-if-it-is-an-issue.md
+++ b/how-to/not-sure-if-it-is-an-issue.md
@@ -6,6 +6,12 @@ permalink: /how-to-test/not-sure-if-it-is-an-issue/
 
 When conducting accessibility testing, testers may come across barriers that could be accessibility-related issues, or they could be unrelated. If you're unsure whether the problem you've identified is a genuine accessibility issue, the following steps can help you verify it.
 
+Accessibility testing is important because it helps to ensure that everyone can use a website or application, regardless of their disability. This includes people who are blind, deaf, have low vision, or have mobility impairments.
+
+To thoroughly test web accessibility, a combination of manual and automated testing methods are performed against the [Web Content Accessibility Guidelines](https://www.w3.org/TR/WCAG21/)) (WCAG) 2.1 Level A and AA. Manual testing involves people navigating the site, using assistive technologies like screen readers or keyboard-only navigation, and verifying if all content is perceivable, operable, understandable. Automated testing utilizes specialized tools to scan for common accessibility issues, such as missing alternative text for images or improper heading structure.
+
+By combining both approaches, we can identify and address accessibility barriers comprehensively, improving the overall user experience and inclusivity of our digital products.
+
 ## <step-number>1</step-number> Test against Magentaa11y.com
 {: .divider }
 A good first step is to test against MagentaA11y.com patterns.  Each pattern includes a How to Test section, code samples, notes about expected functionality, and clear acceptance criteria.


### PR DESCRIPTION
Removed generic text from the How To Test page to simplify.