### PR TITLE
Add new stepper component

### DIFF
--- a/_checklist-web/stepper-input.md
+++ b/_checklist-web/stepper-input.md
@@ -94,7 +94,7 @@ wcag:
 ## Code examples
 
 ### Speciality stepper integer input
-Before using this pattern, consider if using a plain [Select dropdown](https://www.magentaa11y.com/checklist-web/select/) which might be more clear and simple for all users. A select does everything that this stepper does, and with less code! Plus, a select is native and accessible out of the box.
+Before using this pattern, consider if using a plain [Select dropdown](https://www.magentaa11y.com/checklist-web/select/) might be more clear and simple for all users. A select does everything that this stepper does, and with less code! Plus, a select is native and accessible out of the box.
 
 This component is useful for small range increments. If the max count is more than 20, consider use of a [Text Input](http://127.0.0.1:4000/checklist-web/text-input/) field as this component will be cumbersome for people using a mouse.
 
@@ -117,5 +117,7 @@ This component is useful for small range increments. If the max count is more th
 - The value of the `select` element naturally communicates the updated value to screen reader users so the live container is not updated when that form element is interacted with.
 
 - The `button` `aria-label` values should be plain text and they should include context of what they affect when activated (typically the label for the `select`).  e.g. Increase Quantity, Add Quantity
+
+- <code>aria-disabled="true"</code> will be applied to the buttons when either end of the range is reached
 
 - Related alternative patterns: [Select dropdown](https://www.magentaa11y.com/checklist-web/select/) or an [ARIA Spinbutton](https://www.w3.org/WAI/ARIA/apg/patterns/spinbutton/examples/datepicker-spinbuttons/).

--- a/_checklist-web/stepper-input.md
+++ b/_checklist-web/stepper-input.md
@@ -40,7 +40,7 @@ screenreader:
 
 gherkin-keyboard: 
   - when:  |
-      the tab key to move focus form fields
+      the tab key to move focus to the first interactive item
     result: |
       focus is strongly visually indicated
   - then:  |

--- a/_checklist-web/stepper-input.md
+++ b/_checklist-web/stepper-input.md
@@ -1,0 +1,118 @@
+---
+layout: entry
+title:  "Stepper input"
+description: "How to code and test an accessible stepper input"
+categories: form
+
+keyboard:
+  tab: |
+    Focus moves to either the select field or buttons
+  enter or spacebar: |
+    If select is focused, expands the select and places focus on the currently selected option in the list 
+    If focus is in the options, collapses the select and keeps the currently selected option.
+    If focus is on one of the buttons, it will either increment or decrement the value
+  arrow-keys: |
+    If select is focused, moves focus to and selects the next option
+  escape: |
+    If the select is displayed, collapses the select and moves focus to the button
+  home: |
+    If the select is displayed, moves focus to and selects the first option
+  end: |
+    If the select is displayed, moves focus to and selects the last option
+     
+mobile:
+  swipe: |
+    Moves focus to each form control in the pattern
+  double-tap: |
+    If select is focused, opens select, selects option
+    If a button is focused, it will either increment or decrement the value
+screenreader:
+  name:  |
+    Button labels are clear and include context
+    The select field's visual label is announced
+  role:  |
+    For the select field it identifies itself as a select, popup button, menu/submenu or listbox
+    For the buttons they are identified as button
+  group: |
+    Its label is read with the input
+  state: |
+    It indicates when the select is expanded/collapsed, indicates which option is selected
+
+gherkin-keyboard: 
+  - when:  |
+      the tab key to move focus form fields
+    result: |
+      focus is strongly visually indicated
+  - then:  |
+      the arrow keys to select an option
+    result: |
+      the selected option is changed
+  - then:  |
+      the escape key when the select is open 
+    result: |
+      it collapses and focus moves to the select
+  - when:  |
+      the enter key is pressed on buttons
+    result: |
+      the value is incremented or decremented    
+
+gherkin-mobile:
+  - when:  |
+      swipe to focus on the form fields
+  - then:  |
+      doubletap with the select in focus
+    result: |
+      the picker/spinner opens
+  - then:  |
+      doubletap with the button in focus
+    result: |
+      the value is incremented or decremented
+
+wcag:
+  - name: Perceivable
+    list:
+      - criteria: Is easy to identify as interactive
+      - criteria: Color is not used as the only means of conveying information
+  - name: Operable
+    list:
+      - criteria: Is keyboard operable
+      - criteria: The click/tap target area is no smaller than 44x44px
+      - criteria: The disabled and focus states have a 3:1 minimum contrast ratio against default
+      - criteria: The focus indication has a 3:1 minimum contrast ratio against adjacent elements
+      - criteria: The focus indication has a minimum area equal to the width of the element and 2px in height
+      - criteria: The form field label in the code contains the text that is visually presented
+  - name: Understandable
+    list:
+      - criteria: Its purpose is clear in the context of the whole page
+  - name: Robust
+    list:
+      - criteria: Conveys the correct semantic role 
+      - criteria: Expresses its state (if applicable)
+      - criteria: Meets criteria across platforms, devices and viewports
+---
+
+## Code examples
+
+### Speciality stepper integer input
+
+This component is useful for small-ish selections. If the max count is more than 20, this component will be cumbersome for people using a mouse.
+
+{% highlight html %}
+{% include /examples/input-select-stepper.html %}
+{% endhighlight %}
+
+{::nomarkdown}
+<example>
+{% include /examples/input-select-stepper.html %}
+</example>
+{:/}
+
+## Developer notes
+
+This stepper example provides both `button` and `select` elements for users to change a value.
+
+A non-visual live container with `aria-live="polite"` is present in the page at DOM load. When the `button` elements are activated, this non-visual live container is updated with dynamic content that screen reader users will hear announced as they increment or decrement the value. This dynamic text is then removed from the DOM after a few seconds (but not the actual container with `aria-live="polite"`) so the message is not discovered by screen reader users after interaction.
+
+The value of the `select` element naturally communicates the updated value to screen reader users so the live container is not updated when that form element is interacted with.
+
+The `button` `aria-label` values should be plain text and they should include context of what they affect when activated (typically the label for the `select`).  e.g. Increase Quantity, Add Quantity

--- a/_checklist-web/stepper-input.md
+++ b/_checklist-web/stepper-input.md
@@ -94,8 +94,9 @@ wcag:
 ## Code examples
 
 ### Speciality stepper integer input
+Before using this pattern, consider if using a plain [Select dropdown](https://www.magentaa11y.com/checklist-web/select/) which might be more clear and simple for all users. A select does everything that this stepper does, and with less code! Plus, a select is native and accessible out of the box.
 
-This component is useful for small-ish selections. If the max count is more than 20, this component will be cumbersome for people using a mouse.
+This component is useful for small range increments. If the max count is more than 20, consider use of a [Text Input](http://127.0.0.1:4000/checklist-web/text-input/) field as this component will be cumbersome for people using a mouse.
 
 {% highlight html %}
 {% include /examples/input-select-stepper.html %}
@@ -109,10 +110,12 @@ This component is useful for small-ish selections. If the max count is more than
 
 ## Developer notes
 
-This stepper example provides both `button` and `select` elements for users to change a value.
+- This stepper example provides both `button` and `select` elements for users to change a value.
 
-A non-visual live container with `aria-live="polite"` is present in the page at DOM load. When the `button` elements are activated, this non-visual live container is updated with dynamic content that screen reader users will hear announced as they increment or decrement the value. This dynamic text is then removed from the DOM after a few seconds (but not the actual container with `aria-live="polite"`) so the message is not discovered by screen reader users after interaction.
+- A non-visual live container with `aria-live="polite"` is present in the page at DOM load. When the `button` elements are activated, this non-visual live container is updated with dynamic content that screen reader users will hear announced as they increment or decrement the value. This dynamic text is then removed from the DOM after a few seconds (but not the actual container with `aria-live="polite"`) so the message is not discovered by screen reader users after interaction.
 
-The value of the `select` element naturally communicates the updated value to screen reader users so the live container is not updated when that form element is interacted with.
+- The value of the `select` element naturally communicates the updated value to screen reader users so the live container is not updated when that form element is interacted with.
 
-The `button` `aria-label` values should be plain text and they should include context of what they affect when activated (typically the label for the `select`).  e.g. Increase Quantity, Add Quantity
+- The `button` `aria-label` values should be plain text and they should include context of what they affect when activated (typically the label for the `select`).  e.g. Increase Quantity, Add Quantity
+
+- Related alternative patterns: [Select dropdown](https://www.magentaa11y.com/checklist-web/select/) or an [ARIA Spinbutton](https://www.w3.org/WAI/ARIA/apg/patterns/spinbutton/examples/datepicker-spinbuttons/).

--- a/_checklist-web/stepper-input.md
+++ b/_checklist-web/stepper-input.md
@@ -112,7 +112,7 @@ This component is useful for small range increments. If the max count is more th
 
 - This stepper example provides both `button` and `select` elements for users to change a value.
 
-- A non-visual live container with `aria-live="polite"` is present in the page at DOM load. When the `button` elements are activated, this non-visual live container is updated with dynamic content that screen reader users will hear announced as they increment or decrement the value. This dynamic text is then removed from the DOM after a few seconds (but not the actual container with `aria-live="polite"`) so the message is not discovered by screen reader users after interaction.
+- A non-visual live container with `aria-live="polite"` is present in the page at DOM load. When the `button` elements are activated, this non-visual live container is updated with dynamic content that screen reader users will hear announced as they increment or decrement the value. This dynamic text is then removed from the DOM after a few seconds (but not the actual container with `aria-live="polite"`) so the message is not discovered by screen reader users after interaction. The content of this message dynamically created based on the <code>Label</code> for the <code>Select</code> and the current value of the <code>Select</code>. e.g. "Quantity updated, 4"
 
 - The value of the `select` element naturally communicates the updated value to screen reader users so the live container is not updated when that form element is interacted with.
 

--- a/_includes/examples/input-select-stepper.html
+++ b/_includes/examples/input-select-stepper.html
@@ -21,6 +21,6 @@
     <option value="11">11</option>
   </select>
   <button class="button plus" aria-label="Increase Quantity"></button>
-  <!-- live container -->
+  <!-- live container where "Quanity updated, {x}" will be dynamically updated -->
   <div aria-live="polite" class="hidden" id="stepper-status-target"></div>
 </div>

--- a/_includes/examples/input-select-stepper.html
+++ b/_includes/examples/input-select-stepper.html
@@ -2,33 +2,25 @@
   <label for="stepper">
     Quantity
   </label>
-  <button class="button minus">
-    <span class="hidden">
-      Decrease Quantity
-    </span>
-  </button>
+  <button class="button minus" aria-label="Decrease Quantity" aria-disabled="true"></button>
   <select id="stepper"
           name="stepper-input"
           min="1"
           max="11"
           data-selected="1">
-    <option label="1" selected>1</option>
-    <option label="2">2</option>
-    <option label="3">3</option>
-    <option label="4">4</option>
-    <option label="5">5</option>
-    <option label="6">6</option>
-    <option label="7">7</option>
-    <option label="8">8</option>
-    <option label="9">9</option>
-    <option label="10">10</option>
-    <option label="11">11</option>
+    <option value="1" selected>1</option>
+    <option value="2">2</option>
+    <option value="3">3</option>
+    <option value="4">4</option>
+    <option value="5">5</option>
+    <option value="6">6</option>
+    <option value="7">7</option>
+    <option value="8">8</option>
+    <option value="9">9</option>
+    <option value="10">10</option>
+    <option value="11">11</option>
   </select>
-  <button class="button plus">
-    <span class="hidden">
-      Increase Quantity
-    </span>
-  </button>
+  <button class="button plus" aria-label="Increase Quantity"></button>
   <!-- live container -->
   <div aria-live="polite" class="hidden" id="stepper-status-target"></div>
 </div>

--- a/_includes/examples/input-select-stepper.html
+++ b/_includes/examples/input-select-stepper.html
@@ -1,14 +1,13 @@
 <div class="stepper">
-  <label for="stepper-cowbell">
-    How much cowbell?
+  <label for="stepper">
+    Quantity
   </label>
-  <div class="stepper-overlay"
-       id="stepper-overlay" 
-       data-selected="1"
-       aria-hidden="true">
-    <!-- Covers the select to ensure uniform styles -->
-  </div>
-  <select id="stepper-cowbell"
+  <button class="button minus">
+    <span class="hidden">
+      Decrease Quantity
+    </span>
+  </button>
+  <select id="stepper"
           name="stepper-input"
           min="1"
           max="11"
@@ -25,14 +24,11 @@
     <option label="10">10</option>
     <option label="11">11</option>
   </select>
-  <div class="button minus" aria-hidden="true">
+  <button class="button plus">
     <span class="hidden">
-      Less cowbell
+      Increase Quantity
     </span>
-  </div>
-  <div class="button plus" aria-hidden="true">
-    <span class="hidden">
-      More cowbell
-    </span>
-  </div>
+  </button>
+  <!-- live container -->
+  <div aria-live="polite" class="hidden" id="stepper-status-target"></div>
 </div>

--- a/_sass/modules/_input-stepper.scss
+++ b/_sass/modules/_input-stepper.scss
@@ -21,6 +21,17 @@
     justify-self: center;
   }
 
+  .plus[aria-disabled="true"]:hover:before, 
+  .minus[aria-disabled="true"]:hover:before,
+  .plus[aria-disabled="true"]:focus:before, 
+  .minus[aria-disabled="true"]:focus:before {
+    top: 0.75rem;
+    left: 0.75rem;
+    width: 1.5rem;
+    height: 1.5rem;
+    opacity: 1;
+  }
+
   .stepper-overlay {
     grid-column: 2 / span 1;
     grid-row: 2;

--- a/_sass/modules/_input-stepper.scss
+++ b/_sass/modules/_input-stepper.scss
@@ -32,6 +32,11 @@
     opacity: 1;
   }
 
+  .plus[aria-disabled="true"]:before,
+  .minus[aria-disabled="true"]:before {
+    filter: invert(.7);
+  }
+
   .stepper-overlay {
     grid-column: 2 / span 1;
     grid-row: 2;

--- a/_sass/modules/_input-stepper.scss
+++ b/_sass/modules/_input-stepper.scss
@@ -42,28 +42,9 @@
       content: ''attr(data-selected)'';
     }
   }
-
   select[name="stepper-input"] {
-    display: inline;
-    position: relative;
-    height: 3rem;
-    appearance: none;
-    overflow: visible;
-    background: none;
-    margin: 0px;
-    padding: 0;
-    border: none;
-    grid-column: 2 / span 1;
-    grid-row: 2;
-    justify-self: stretch;
-    font-family: monospace;
-    transition: 0s;
-    z-index: 1;
-
-    &:focus {
-      outline: .25rem solid rgba($color-focus, .5);
-      outline-offset: 0rem;
-      transition: .2s;
-    }
+    padding: 0.75rem 2rem 0.75rem 0.5rem !important;
+    border: 2px solid #c5c5c5;
   }
+
 }

--- a/assets/scripts/index.js
+++ b/assets/scripts/index.js
@@ -151,7 +151,9 @@ if ( $('dialog').length ) {
 const 
     $stepper = $(".stepper"),
     stepperLabel = $stepper.find("label").text(),
-    $stepperStatusTarget = $stepper.find("#stepper-status-target");
+    $stepperStatusTarget = $stepper.find("#stepper-status-target"),
+    $stepperMinButton = $(".minus"),
+    $stepperMaxButton = $(".plus");
 
     function removeStepperLiveMessage(delay){
         if(!delay){ delay = 2000; }
@@ -160,14 +162,42 @@ const
         }, delay);
     }
 
-$(".minus").click(function(){
+    $("#stepper").on("change", function() {
+        // get the value of the select element
+        const value = parseInt($(this).val()),
+            min = parseInt($(this).attr("min")),
+            max = parseInt($(this).attr("max"));
+        if(value > min || value < max){
+            $stepperMaxButton.removeAttr("aria-disabled");
+            $stepperMinButton.removeAttr("aria-disabled");
+        }
+        if(value === min){
+            $stepperMinButton.attr("aria-disabled","true");
+            $stepperMaxButton.removeAttr("aria-disabled");
+        }
+        if(value === max){
+            $stepperMaxButton.attr("aria-disabled","true");
+            $stepperMinButton.removeAttr("aria-disabled");
+        }
+      });
+
+$stepperMinButton.click(function(){
     var overlay = $(this).parents(".stepper").find("#stepper-overlay");
     var inpt = $(this).parents(".stepper").find("[name=stepper-input]");
     var min = $(this).parents(".stepper").find("[name=stepper-input]").attr('min');
+    var max = $(this).parents(".stepper").find("[name=stepper-input]").attr('max');
     var val = parseInt(inpt.val());
     if ( val < 1 ) inpt.val(val=1);
     if ( val < 1 ) inpt.attr('data-selected', '1');
-    if ( val == min ) return;
+    if ( val-1 == min ){
+        $stepperMinButton.attr("aria-disabled","true");
+    };
+    if( val-1 < max){
+        $stepperMaxButton.removeAttr("aria-disabled");
+    }
+    if ( val == min ){
+        return;
+    };
     inpt.val(val-1);
     inpt.attr('data-selected', val-1);
     overlay.attr('data-selected', val-1);
@@ -175,11 +205,17 @@ $(".minus").click(function(){
     removeStepperLiveMessage(2000);
 });
 
-$(".plus").click(function(){
+$stepperMaxButton.click(function(){
     var overlay = $(this).parents(".stepper").find("#stepper-overlay");
     var inpt = $(this).parents(".stepper").find("[name=stepper-input]");
     var max = $(this).parents(".stepper").find("[name=stepper-input]").attr('max');
     var val = parseInt(inpt.val());
+    if(val+1 > 1){
+        $stepperMinButton.removeAttr("aria-disabled");
+    }
+    if(parseInt(val) === parseInt(max -1)){
+        $stepperMaxButton.attr("aria-disabled","true");
+    }
     if ( val == max ) return;
     inpt.val(val+1);
     inpt.attr('data-selected', val+1);

--- a/assets/scripts/index.js
+++ b/assets/scripts/index.js
@@ -147,12 +147,18 @@ if ( $('dialog').length ) {
     });
 }
 
-$("[name='stepper-input']").on('change', function() {
-    var overlay = $(this).parents(".stepper").find("#stepper-overlay");
-    var val = parseInt($(this).val());
-    $(this).attr('data-selected', val);
-    overlay.attr('data-selected', val);
-});
+// Stepper
+const 
+    $stepper = $(".stepper"),
+    stepperLabel = $stepper.find("label").text(),
+    $stepperStatusTarget = $stepper.find("#stepper-status-target");
+
+    function removeStepperLiveMessage(delay){
+        if(!delay){ delay = 2000; }
+        setTimeout(() => {
+            $stepperStatusTarget.html("");
+        }, delay);
+    }
 
 $(".minus").click(function(){
     var overlay = $(this).parents(".stepper").find("#stepper-overlay");
@@ -165,6 +171,8 @@ $(".minus").click(function(){
     inpt.val(val-1);
     inpt.attr('data-selected', val-1);
     overlay.attr('data-selected', val-1);
+    $stepperStatusTarget.html(stepperLabel + "updated, " + parseInt(val - 1));
+    removeStepperLiveMessage(2000);
 });
 
 $(".plus").click(function(){
@@ -176,6 +184,8 @@ $(".plus").click(function(){
     inpt.val(val+1);
     inpt.attr('data-selected', val+1);
     overlay.attr('data-selected', val+1);
+    $stepperStatusTarget.html(stepperLabel + "updated, " + parseInt(val + 1));
+    removeStepperLiveMessage(2000);
 });
 
 


### PR DESCRIPTION
1. Reintroduced standard Select with traditional Select look and feel 
3. Changed markup order to match visual order so things land as button > select > button 
4. Converted fake buttons into real buttons 
5. Added a visually hidden live container to support dynamic updates 
6. Changed non-visual button labels to "decrease" "increase" from "more/less" and included context - decrement/increment not plain language
7. Updated Gherkin, condensed, and WCAG How to test
8. Updated Dev notes
9. Removed lessons learned