### PR TITLE
Recode radio buttons with nested controls

### DIFF
--- a/_checklist-web/radio.md
+++ b/_checklist-web/radio.md
@@ -164,16 +164,14 @@ This custom button requires extra scripting work for roving tabindex and event l
 
 ### Radio mixed with interactive elements
 
-**Avoid** placing interactive elements between radio buttons.
+**Avoid** placing interactive elements between radio buttons. Radio groups are not supposed to consist of nested interactive elements.
 
-- Radio button focus order is not what you think it is.
-- When nothing is selected, tab order moves through as expected. 
-- However, as soon as a radio button is selected, the selected radio input receives focus first from the group. 
-
-#### Checkbox radio hack
-
-- This hack must be used very carefully on a case by case basis.
-- With great power comes great responsibility.
+- Radio button focus order is not what you may expect
+- By default, it is not expected behavior that each radio button can be tabbed to. This is how radio buttons naturally behave
+- As soon as a radio button is selected, the selected radio input receives focus first from the group. As a result screen reader users may not discover a nested control for an option.
+- To try to mitigate screen reader users not discovering the nested controls, describe the fieldset / radiogroup with non-visual text. This can be done with <code>aria-describedby</code> on the <code>fieldset</code>
+- Ensure the nested controls also have additional context defined by <code>aria-describedby</code>. This will help screen reader users understand their purpose. 
+- Keyboard functionality such as arrow up/down/left/right should change the selected radio button.
   
 {% highlight html %}
 {% include /examples/input-checkbox-radio.html %}
@@ -184,6 +182,7 @@ This custom button requires extra scripting work for roving tabindex and event l
 {% include /examples/input-checkbox-radio.html %}
 </example>
 {:/}
+
 
 ## Developer notes
 

--- a/_checklist-web/radio.md
+++ b/_checklist-web/radio.md
@@ -164,22 +164,22 @@ This custom button requires extra scripting work for roving tabindex and event l
 
 ### Radio mixed with interactive elements
 
-**Avoid** placing interactive elements between radio buttons. Radio groups are not supposed to consist of nested interactive elements.
+**Avoid** Avoid this pattern when possible! Radio groups are not supposed to consist of nested interactive elements. Radio button focus order is not what you may expect.
 
-- Radio button focus order is not what you may expect
 - By default, it is not expected behavior that each radio button can be tabbed to. This is how radio buttons naturally behave
-- As soon as a radio button is selected, the selected radio input receives focus first from the group. As a result screen reader users may not discover a nested control for an option.
-- To try to mitigate screen reader users not discovering the nested controls, describe the fieldset / radiogroup with non-visual text. This can be done with <code>aria-describedby</code> on the <code>fieldset</code>
+- As soon as a radio button is selected, the selected radio input receives focus first from the group. As a result screen reader users may not discover a nested control for an option if they start switching between radio buttons alone
+- To try to mitigate screen reader users not discovering the nested controls, describe the fieldset / radiogroup with non-visual text. This can be done with <code>aria-describedby</code> on the <code>fieldset</code>. For example, "Edit controls are available which follow each radio button"
 - Ensure the nested controls also have additional context defined by <code>aria-describedby</code>. This will help screen reader users understand their purpose. 
+- Use of the same <code>name</code> attribute is important to link the radio buttons as a programmatic group
 - Keyboard functionality such as arrow up/down/left/right should change the selected radio button.
   
 {% highlight html %}
-{% include /examples/input-checkbox-radio.html %}
+{% include /examples/input-radio-styled-group.html %}
 {% endhighlight %}
 
 {::nomarkdown}
 <example>
-{% include /examples/input-checkbox-radio.html %}
+{% include /examples/input-radio-styled-group.html %}
 </example>
 {:/}
 

--- a/_demos/basic-accessible-webpage.md
+++ b/_demos/basic-accessible-webpage.md
@@ -19,5 +19,5 @@ description: This basic web page demonstrates page structure, images, forms and 
 
 
 {::nomarkdown}
-{% include /examples/input-checkbox-radio.html %}
+{% include /examples/input-radio-styled-group.html %}
 {:/}

--- a/_includes/examples/input-checkbox-radio.html
+++ b/_includes/examples/input-checkbox-radio.html
@@ -1,54 +1,36 @@
-<fieldset class="checkbox-radio-group">
+<fieldset class="checkbox-radio-group" aria-describedby="styled-radio-group-helper-text">
   <legend>Choose your payment method:</legend>
-  <input class="radio"
-         type="checkbox"
-         role="radio"
-         name="checkboxRadioGroup"
-         id="checkboxRadioAlpha"
-         aria-describedby="editAlpha"
-         checked>
-  <label for="checkboxRadioAlpha">
+  <!-- visually hidden helper text describing fieldset -->
+  <span class="hidden" id="styled-radio-group-helper-text">
+    Edit controls are available which follow each radio button
+  </span>
+  <input class="radio" type="radio" name="checkboxRadioGroup2" id="checkboxRadioAlpha2" checked>
+  <label for="checkboxRadioAlpha2">
     Alpha
   </label>
-  <button type="button"
-          class="tertiary"
-          id="editAlpha">
+  <button type="button" class="tertiary">
     Edit
     <span class="hidden">
       payment method alpha
     </span>
   </button>
 
-  <input  class="radio"
-          type="checkbox"
-          role="radio"
-          name="checkboxRadioGroup"
-          id="checkboxRadioBravo"
-          aria-describedby="editBravo">
-  <label for="checkboxRadioBravo">
+  <input class="radio" type="radio" name="checkboxRadioGroup2" id="checkboxRadioBravo2">
+  <label for="checkboxRadioBravo2">
     Bravo
   </label>
-  <button type="button"
-          class="tertiary"
-          id="editBravo">
+  <button type="button" class="tertiary">
     Edit
     <span class="hidden">
       payment method Bravo
     </span>
   </button>
 
-  <input class="radio"
-         type="checkbox"
-         role="radio"
-         name="checkboxRadioGroup"
-         id="checkboxRadioCharlie"
-         aria-describedby="editCharlie">
-  <label for="checkboxRadioCharlie">
+  <input class="radio" type="radio" name="checkboxRadioGroup2" id="checkboxRadioCharlie3">
+  <label for="checkboxRadioCharlie3">
     Charlie
   </label>
-  <button type="button"
-          class="tertiary"
-          id="editCharlie">
+  <button type="button" class="tertiary">
     Edit
     <span class="hidden">
       payment method Charlie

--- a/_includes/examples/input-radio-styled-group.html
+++ b/_includes/examples/input-radio-styled-group.html
@@ -8,32 +8,23 @@
   <label for="checkboxRadioAlpha2">
     Alpha
   </label>
-  <button type="button" class="tertiary">
+  <button type="button" class="tertiary" aria-describedby="checkboxRadioAlpha2">
     Edit
-    <span class="hidden">
-      payment method alpha
-    </span>
   </button>
 
   <input class="radio" type="radio" name="checkboxRadioGroup2" id="checkboxRadioBravo2">
   <label for="checkboxRadioBravo2">
     Bravo
   </label>
-  <button type="button" class="tertiary">
+  <button type="button" class="tertiary" aria-describedby="checkboxRadioBravo2">
     Edit
-    <span class="hidden">
-      payment method Bravo
-    </span>
   </button>
 
   <input class="radio" type="radio" name="checkboxRadioGroup2" id="checkboxRadioCharlie3">
   <label for="checkboxRadioCharlie3">
     Charlie
   </label>
-  <button type="button" class="tertiary">
+  <button type="button" class="tertiary" aria-describedby="checkboxRadioCharlie3">
     Edit
-    <span class="hidden">
-      payment method Charlie
-    </span>
   </button>
 </fieldset>


### PR DESCRIPTION
This PR includes a recode of the special use case [Radio mixed with interactive elements](https://www.magentaa11y.com/checklist-web/radio/#specialty-use-cases). The goal is to move away from the ARIA Checkbox approach in trade for more traditional Radio buttons.

While keyboard focus order is not ideal, because of the design anti-pattern, standard keyboard functionality for Radio buttons (up/down/right/left) arrows and other accessibility wins are now present.

Changes/Improvements:
- Native Radio buttons instead of checkboxes with radio roles
- Native / expected keyboard support for Radio
- Number of options available now communicated to screen reader
- No longer triggering accessibility violations in some automated accessibility testing engines due to missing ARIA `aria-checked` `role="radio"` on native checkbox.
- Pattern no longer breaks ARIA use rules [#1 and #2](https://www.w3.org/TR/using-aria/#firstrule)
- Reduced risk but not by much
- Visually hidden content informing screen reader users about nearby controls