### PR TITLE
Links and buttons updates

### DIFF
--- a/_sass/modules/_how-to-test.scss
+++ b/_sass/modules/_how-to-test.scss
@@ -181,6 +181,22 @@
   }
 }
 
+/* How to test links and buttons visually disabled but actionable button */
+.visually-disabled {
+  color: $color-text;
+  background: $color-button-disabled;
+  &:before,
+  &:after {
+    background-image: var(--icon-chevron-gray);
+  }
+  cursor: pointer;
+  &:hover,
+  &:active,
+  &:focus {
+    color: $color-text;
+    background: $color-button-disabled;
+  }
+}
 
 /*Examples for How to test forms - checkboxes */
 

--- a/_sass/modules/_nav-breadcrumbs.scss
+++ b/_sass/modules/_nav-breadcrumbs.scss
@@ -52,6 +52,7 @@
 
       &:last-of-type {
         a {
+          font-family: "teleneo-xtra-bold", sans-serif;
           padding-right: .75rem;
           border-radius: 0 .5rem .5rem 0;
           &:after {

--- a/assets/scripts/index.js
+++ b/assets/scripts/index.js
@@ -625,6 +625,7 @@ $('#goodErrorInputSubmit').click(function(e) {
     e.preventDefault();
     $('#goodErrorInputError').show();
     $('#goodErrorInput').focus();
+    $('#goodErrorInput').attr('aria-invalid', 'true');
 });
 
 $('#badErrorInputSubmit').click(function(e) {

--- a/how-to/form.md
+++ b/how-to/form.md
@@ -89,11 +89,11 @@ Select fields allow users to select one or more options from an expandable list 
     <tr>
       <td>
           <input type="checkbox" id="accessibleCheckbox">
-          <label for="accessibleCheckbox">Accessible Checkbox</label>
+          <label for="accessibleCheckbox">Accessible</label>
       </td>
       <td>
           <input style="display:none" type="checkbox" id="inaccessibleCheckbox">
-          <label for="inaccessibleCheckbox">Inaccessible Checkbox</label>
+          <label for="inaccessibleCheckbox">Inaccessible</label>
       </td>
     </tr>  
     </tbody>
@@ -143,26 +143,26 @@ Select fields allow users to select one or more options from an expandable list 
     <tr>
       <td>
         <label for="selectPass">
-          Select a number
+          Select a Nato phonetic letter
         </label>
         <select id="selectPass">
-          <option value="None" selected disabled>Select a number</option>
-          <option value="1">One</option>
-          <option value="2">Two</option>
-          <option value="3">Three</option>
+          <option value="None" selected disabled>Select a letter</option>
+          <option value="Alpha">Alpha</option>
+          <option value="Bravo">Bravo</option>
+          <option value="Charlie">Charlie</option>
         </select>
         <button aria-disabled="true" class="button" id="submitSelectPassSelection" type="submit">Submit</button>
         <div role="alert" id="messagePass" style="display: none;">This was an expected submission!</div>
       </td>
       <td>
         <label for="selectFail">
-          Select a number
+          Select a Nato phonetic letter
         </label>
         <select id="selectFail">
-          <option value="None" selected disabled>Select a number</option>
-          <option value="1">One</option>
-          <option value="2">Two</option>
-          <option value="3">Three</option>
+          <option value="None" selected disabled>Select a letter</option>
+          <option value="Alpha">Alpha</option>
+          <option value="Bravo">Bravo</option>
+          <option value="Charlie">Charlie</option>
         </select>
         <div id="messageFail" style="display: none;">This was an unexpected submission!</div>
       </td>
@@ -297,7 +297,7 @@ Select fields allow users to select one or more options from an expandable list 
 
 <div class="how-to-test-checklist-item">
   <h3>✓ Ensure there is proper error handling for required fields</h3>
-  <p><strong>Note:</strong> When error text is not programmatically associated by use of <code>aria-describedby</code> they may not be discovered by screen reader users.</p>
+  <p><strong>Note:</strong> Error messages should be announced for screen reader users when the form recives focus. Forms should also notify screen reader users if invalid content has been entered in a field.</p>
   <table class="column-2">
     <thead>
       <th scope="col">

--- a/how-to/form.md
+++ b/how-to/form.md
@@ -297,7 +297,7 @@ Select fields allow users to select one or more options from an expandable list 
 
 <div class="how-to-test-checklist-item">
   <h3>✓ Ensure there is proper error handling for required fields</h3>
-  <p><strong>Note:</strong> Error messages should be announced for screen reader users when the form recives focus. Forms should also notify screen reader users if invalid content has been entered in a field.</p>
+  <p><strong>Note:</strong> Error messages should be announced for screen reader users when the form field receives focus. Forms should also notify screen reader users if invalid content has been entered in a field.</p>
   <table class="column-2">
     <thead>
       <th scope="col">

--- a/how-to/link-button.md
+++ b/how-to/link-button.md
@@ -34,7 +34,7 @@ Use a screen reader, such as [NVDA](https://www.nvaccess.org/) (for Windows) or 
         <button>I get focus!</button>
       </td>
       <td>
-        <button tabindex="-1">I do NOT get focus</button>
+        <div class="button">I do NOT get focus</div>
       </td>
     </tr>  
       <tr>
@@ -94,7 +94,7 @@ Use a screen reader, such as [NVDA](https://www.nvaccess.org/) (for Windows) or 
         Preferred
       </th>
       <th scope="col">
-        Disabled but not focusable
+        Visually disabled but actionable
       </th>
     </thead>
     <tbody>
@@ -103,7 +103,7 @@ Use a screen reader, such as [NVDA](https://www.nvaccess.org/) (for Windows) or 
         <button aria-disabled="true">Save</button>
       </td>
       <td>
-        <button disabled>Save</button>
+        <button class="visually-disabled" tabindex="-1" onmouseup="alert('This disabled button is still actionable for mouse and screen readers users!')">Save</button>
       </td>
     </tr>  
     </tbody>


### PR DESCRIPTION
Updates to How To Test Links and Buttons:

- Used a div button instead of negative tabindex as non-focusable example
- Updated disabled button example to look disabled but still be actionable
- updated the last ("current") breadcrumb link to be bold