### PR TITLE
Add new big link Product Card example

### DIFF
--- a/_checklist-web/link.md
+++ b/_checklist-web/link.md
@@ -103,7 +103,7 @@ This semantic HTML contains all accessibility features by default.
 ### Name links logically
 
 - **Do not** use a heading with a generic link below. 
-- Instead, make the heading a link.
+- Instead, make the heading a link or programmatically associate the link with the heading using <code>aria-describedby</code>.
 
 {% highlight html %}
 <h3>About our coffee subscriptions</h3>
@@ -112,6 +112,19 @@ This semantic HTML contains all accessibility features by default.
    Learn more
 </div>
 {% endhighlight %}{: .bad-example}
+
+{% highlight html %}
+<h3><a href="/about/">About our coffee subscriptions</a></h3>
+<p>Get the best coffee delivered to your door</p>
+{% endhighlight %}{: .good-example}
+
+{% highlight html %}
+<h3 id="unique-id">About our coffee subscriptions</h3>
+<p>Get the best coffee delivered to your door</p>
+<a href="/about/" aria-describedby="unique-id">
+   Learn more
+</div>
+{% endhighlight %}{: .good-example}
 
 ### Making a link with no `href` focusable
 
@@ -199,12 +212,6 @@ Sometimes the design will call for multiple links with the same text label. In a
 {% endhighlight %}
 
 ### Complex examples
-
-- **Don't** wrap large blocks of content or nest other interactive components inside a link.
-- This complex example uses a simple link and references product information using `aria-describedby`
-- This allows the link to be read first (without the repetition of the image alt text) and then the screen reader will read the related product information (colors, pricing).
-- The HTML is **written in logical order** for the screen reader and CSS grid layout is used to re-arrange the elements visually.
-- No Javascript is used, this example uses well supported CSS only techniques
 
 <example>
 {% include /examples/product.html %}

--- a/_includes/examples/product.html
+++ b/_includes/examples/product.html
@@ -70,7 +70,7 @@
 
 <h2 class="h-bravo">Product Card with multiple controls</h2>
 <p>This example demonstrates an approach taken for when the card may have multiple controls within it. This pattern was inspired by <a href="https://inclusive-components.design/cards/">Inclusive Components: Cards</a>.</p>
-<p><strong>Note:</strong> This approach works well for screen reader users but introduces challenges for voice recognition users because the fake "See Details" button is hidden from assistive technology. This pattern also introduces barriers for text-to-speech users because text selection by use of the mouse within the card is difficult.</p>
+<p><strong>Note:</strong> This approach works well for screen reader users but introduces challenges for voice recognition users because the fake "See Details" button is hidden from assistive technology. Speech-to-text users will have difficulty selecting text for speech output with this pattern.</p>
 <ul class="product-list multiple-controls">
   <li class="product-list-item">
     <div class="offer-container">

--- a/_includes/examples/product.html
+++ b/_includes/examples/product.html
@@ -70,7 +70,7 @@
 
 <h2 class="h-bravo">Product Card with multiple controls</h2>
 <p>This example demonstrates an approach taken for when the card may have multiple controls within it. This pattern was inspired by <a href="https://inclusive-components.design/cards/">Inclusive Components: Cards</a>.</p>
-<p><strong>Note:</strong> This approach works well for screen reader users but introduces challenges for voice recognition users because the fake "See Details" button is hidden from assistive technology. Additionally, this pattern introduces barriers for text-to-speech users because text selection, by use of the mouse within the card, is difficult.</p>
+<p><strong>Note:</strong> This approach works well for screen reader users but introduces challenges for voice recognition users because the fake "See Details" button is hidden from assistive technology. This pattern also introduces barriers for text-to-speech users because text selection by use of the mouse within the card is difficult.</p>
 <ul class="product-list multiple-controls">
   <li class="product-list-item">
     <div class="offer-container">

--- a/_includes/examples/product.html
+++ b/_includes/examples/product.html
@@ -1,3 +1,69 @@
+<h2 class="h-bravo">Product Card with multiple controls</h2>
+<p>This example demonstrates an approach taken for when the card may have multiple controls within it.</p>
+<ul class="product-list multiple-controls">
+  <li class="product-list-item">
+    <div class="offer-container">
+      <button type="button" class="tertiary" aria-label="Save $400 with offer for mPhone Universe Max Extra Phabulous">
+        Save $400 with offer
+      </button>
+    </div>
+
+    <div class="link-container">
+      <!-- The link DOES NOT wrap the entire description -->
+      <h3 class="product-heading">
+        <a class="product-link" href="/demos/">
+          <span class="brand">
+            mPhone
+          </span>
+          <span class="product-title">
+            Universe Max Extra Phabulous
+          </span>
+        </a>
+      </h3>
+      <div class="product-image-container">
+        <img class="product-image" src="/assets/images/products/mobile-phone.png" alt="mPhone Universe Max Extra Phabulous"/>
+      </div>
+      <ul id="meta" class="product-meta">
+        <li class="rating">4.8 Stars</li>
+        <li class="network">7G <span class="hidden">network compatibility</span></li>
+      </ul>
+      <div class="end-cap">
+        <ul id="colors" class="product-colors">
+          <li class="red"><span class="hidden">Sunset Red</span></li>
+          <li class="gold"><span class="hidden">Golden Canyon</span></li>
+          <li class="blue"><span class="hidden">Blue</span></li>
+          <li class="gray"><span class="hidden">Graphite</span></li>
+        </ul>
+        <ul id="pricing" class="product-pricing">
+          <li class="monthly">
+            <div><strong>Monthly</strong></div>
+            <strong>
+              $22.00<span class="hidden">,</span>
+            </strong>
+            <span class="hidden">
+              Original price:
+            </span>        
+            <s>$50.00</s>
+            <div>For 36 months</div>
+          </li>
+          <li class="today">
+            <div><strong>Today</strong></div>
+            $0
+            <div>down + tax</div>
+          </li>
+          <li class="full-price">
+            <strong>Full price</strong> $1,789<span class="hidden">,</span>
+            <span class="hidden">
+              Original price:
+            </span>        
+            <s>$1,998</s>
+          </li>
+        </ul>
+      </div>
+    </div>
+  </li>
+</ul>
+
 <h2 class="h-bravo">Product Card as a single link</h2>
 <p>This card is a single link and does not consist of any other nested controls. Use of <code>aria-labelledby</code> and <code>aria-describedby</code> to control how the card is announced by screen readers.</p>
 <ul class="product-list big-links">
@@ -63,77 +129,5 @@
         </div>
       </div>
     </a>
-  </li>
-</ul>
-
-
-
-<h2 class="h-bravo">Product Card with multiple controls</h2>
-<p>This example demonstrates an approach taken for when the card may have multiple controls within it. This pattern was inspired by <a href="https://inclusive-components.design/cards/">Inclusive Components: Cards</a>.</p>
-<p><strong>Note:</strong> This approach works well for screen reader users but introduces challenges for voice recognition users because the fake "See Details" button is hidden from assistive technology. Speech-to-text users will have difficulty selecting text for speech output with this pattern.</p>
-<ul class="product-list multiple-controls">
-  <li class="product-list-item">
-    <div class="offer-container">
-      <button type="button" class="tertiary" aria-label="Save $400 with offer for mPhone Universe Max Extra Phabulous">
-        Save $400 with offer
-      </button>
-    </div>
-
-    <div class="link-container">
-      <!-- The link DOES NOT wrap the entire description -->
-      <h3 class="product-heading">
-        <a class="product-link" href="/demos/">
-          <span class="brand">
-            mPhone
-          </span>
-          <span class="product-title">
-            Universe Max Extra Phabulous
-          </span>
-        </a>
-      </h3>
-      <div class="product-image-container">
-        <img class="product-image" src="/assets/images/products/mobile-phone.png" alt="mPhone Universe Max Extra Phabulous"/>
-      </div>
-      <ul id="meta" class="product-meta">
-        <li class="rating">4.8 Stars</li>
-        <li class="network">7G <span class="hidden">network compatibility</span></li>
-      </ul>
-      <div class="end-cap">
-        <ul id="colors" class="product-colors">
-          <li class="red"><span class="hidden">Sunset Red</span></li>
-          <li class="gold"><span class="hidden">Golden Canyon</span></li>
-          <li class="blue"><span class="hidden">Blue</span></li>
-          <li class="gray"><span class="hidden">Graphite</span></li>
-        </ul>
-        <ul id="pricing" class="product-pricing">
-          <li class="monthly">
-            <div><strong>Monthly</strong></div>
-            <strong>
-              $22.00<span class="hidden">,</span>
-            </strong>
-            <span class="hidden">
-              Original price:
-            </span>        
-            <s>$50.00</s>
-            <div>For 36 months</div>
-          </li>
-          <li class="today">
-            <div><strong>Today</strong></div>
-            $0
-            <div>down + tax</div>
-          </li>
-          <li class="full-price">
-            <strong>Full price</strong> $1,789<span class="hidden">,</span>
-            <span class="hidden">
-              Original price:
-            </span>        
-            <s>$1,998</s>
-          </li>
-        </ul>
-        <div class="button" aria-hidden="true">
-          See details
-        </div>
-      </div>
-    </div>
   </li>
 </ul>

--- a/_includes/examples/product.html
+++ b/_includes/examples/product.html
@@ -70,7 +70,7 @@
 
 <h2 class="h-bravo">Product Card with multiple controls</h2>
 <p>This example demonstrates an approach taken for when the card may have multiple controls within it. This pattern was inspired by <a href="https://inclusive-components.design/cards/">Inclusive Components: Cards</a>.</p>
-<p><strong>Note:</strong> This approach works well for screen reader users but introduces challenges for voice recognition users because the fake "See Details" button is hidden from assistive technology. Additionally, this pattern introduces barriers for text-to-speech users because text selection with the mouse within the card is difficult.</p>
+<p><strong>Note:</strong> This approach works well for screen reader users but introduces challenges for voice recognition users because the fake "See Details" button is hidden from assistive technology. Additionally, this pattern introduces barriers for text-to-speech users because text selection, by use of the mouse within the card, is difficult.</p>
 <ul class="product-list multiple-controls">
   <li class="product-list-item">
     <div class="offer-container">

--- a/_includes/examples/product.html
+++ b/_includes/examples/product.html
@@ -1,7 +1,7 @@
 <h2 class="h-bravo">Product Card with multiple controls</h2>
 <p>This example demonstrates an approach taken for when the card may have multiple controls within it.</p>
-<ul class="product-list multiple-controls">
-  <li class="product-list-item">
+<div class="product-list multiple-controls">
+  <div class="product-list-item">
     <div class="offer-container">
       <button type="button" class="tertiary" aria-label="Save $400 with offer for mPhone Universe Max Extra Phabulous">
         Save $400 with offer
@@ -61,13 +61,13 @@
         </ul>
       </div>
     </div>
-  </li>
-</ul>
+  </div>
+</div>
 
 <h2 class="h-bravo">Product Card as a single link</h2>
 <p>This card is a single link and does not consist of any other nested controls. Use of <code>aria-labelledby</code> and <code>aria-describedby</code> to control how the card is announced by screen readers.</p>
-<ul class="product-list big-links">
-  <li class="product-list-item">
+<div class="product-list big-links">
+  <div class="product-list-item">
     <a href="/demos/" 
       aria-labelledby="prod-0-eyebrow prod-0-name" 
       aria-describedby="prod-0-meta-rating prod-0-meta-network prod-0-colors product-0-price-monthly product-0-price-today product-0-price-full">
@@ -129,5 +129,5 @@
         </div>
       </div>
     </a>
-  </li>
-</ul>
+  </div>
+</div>

--- a/_includes/examples/product.html
+++ b/_includes/examples/product.html
@@ -1,5 +1,77 @@
-<h2 class="h-bravo">Shop phones</h2>
-<ul class="product-list">
+<h2 class="h-bravo">Product Card as a single link</h2>
+<p>This card is a single link and does not consist of any other nested controls. Use of <code>aria-labelledby</code> and <code>aria-describedby</code> to control how the card is announced by screen readers.</p>
+<ul class="product-list big-links">
+  <li class="product-list-item">
+    <a href="/demos/" 
+      aria-labelledby="prod-0-eyebrow prod-0-name" 
+      aria-describedby="prod-0-meta-rating prod-0-meta-network prod-0-colors product-0-price-monthly product-0-price-today product-0-price-full">
+      <div class="offer-container">
+        <svg style="display: inline-block;" role="img" aria-label="Promo" xmlns="http://www.w3.org/2000/svg" height="1em" viewBox="0 0 448 512"><path d="M0 80V229.5c0 17 6.7 33.3 18.7 45.3l176 176c25 25 65.5 25 90.5 0L418.7 317.3c25-25 25-65.5 0-90.5l-176-176c-12-12-28.3-18.7-45.3-18.7H48C21.5 32 0 53.5 0 80zm112 32a32 32 0 1 1 0 64 32 32 0 1 1 0-64z"/></svg> 15% off your next order
+      </div>
+  
+      <div class="link-container">
+        <h3 class="product-heading">
+            <span class="brand" id="prod-0-eyebrow">
+              mPhone
+            </span>
+            <span class="product-title" id="prod-0-name">
+              Universe Max Extra Phabulous
+            </span>
+        </h3>
+        <div class="product-image-container">
+          <img class="product-image" src="/assets/images/products/mobile-phone.png" alt=""/>
+        </div>
+        <ul id="meta" class="product-meta">
+          <li class="rating" id="prod-0-meta-rating">4.8 Stars</li>
+          <li class="network" id="prod-0-meta-network">7G <span class="hidden">network compatibility</span></li>
+        </ul>
+        <div class="end-cap">
+          <span id="prod-0-colors" class="hidden">Four colors available</span>
+          <!-- hide colors - use visually hidden text x colors avialable -->
+          <!-- reduces verbosity and all colors are available on PDP -->
+          <ul id="colors" class="product-colors" aria-hidden="true">
+            <li class="red"></li>
+            <li class="gold"></li>
+            <li class="blue"></li>
+            <li class="gray"></li>
+          </ul>
+          <ul id="pricing" class="product-pricing">
+            <li class="monthly" id="product-0-price-monthly">
+              <div><strong>Monthly</strong></div>
+              <strong>
+                $22.00<span class="hidden">,</span>
+              </strong>
+              <span class="hidden">
+                Original price:
+              </span>        
+              <s>$50.00</s>
+              <div>For 36 months</div>
+            </li>
+            <li class="today" id="product-0-price-today">
+              <div><strong>Today</strong></div>
+              $0
+              <div>down + tax</div>
+            </li>
+            <li class="full-price" id="product-0-price-full">
+              <strong>Full price</strong> $1,789<span class="hidden">,</span>
+              <span class="hidden">
+                Original price:
+              </span>        
+              <s>$1,998</s>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </a>
+  </li>
+</ul>
+
+
+
+<h2 class="h-bravo">Product Card with multiple controls</h2>
+<p>This example demonstrates an approach taken for when the card may have multiple controls within it. This pattern was inspired by <a href="https://inclusive-components.design/cards/">Inclusive Components: Cards</a>.</p>
+<p><strong>Note:</strong> This approach works well for screen reader users but introduces challenges for voice recognition users because the fake "See Details" button is hidden from assistive technology. Additionally, this pattern introduces barriers for text-to-speech users because text selection with the mouse in the card is difficult.</p>
+<ul class="product-list multiple-controls">
   <li class="product-list-item">
     <div class="offer-container">
       <button type="button" class="tertiary" aria-label="Save $400 with offer for mPhone Universe Max Extra Phabulous">
@@ -25,133 +97,6 @@
       <ul id="meta" class="product-meta">
         <li class="rating">4.8 Stars</li>
         <li class="network">7G <span class="hidden">network compatibility</span></li>
-      </ul>
-      <div class="end-cap">
-        <ul id="colors" class="product-colors">
-          <li class="red"><span class="hidden">Sunset Red</span></li>
-          <li class="gold"><span class="hidden">Golden Canyon</span></li>
-          <li class="blue"><span class="hidden">Blue</span></li>
-          <li class="gray"><span class="hidden">Graphite</span></li>
-        </ul>
-        <ul id="pricing" class="product-pricing">
-          <li class="monthly">
-            <div><strong>Monthly</strong></div>
-            <strong>
-              $22.00<span class="hidden">,</span>
-            </strong>
-            <span class="hidden">
-              Original price:
-            </span>        
-            <s>$50.00</s>
-            <div>For 36 months</div>
-          </li>
-          <li class="today">
-            <div><strong>Today</strong></div>
-            $0
-            <div>down + tax</div>
-          </li>
-          <li class="full-price">
-            <strong>Full price</strong> $1,789<span class="hidden">,</span>
-            <span class="hidden">
-              Original price:
-            </span>        
-            <s>$1,998</s>
-          </li>
-        </ul>
-        <div class="button" aria-hidden="true">
-          See details
-        </div>
-      </div>
-    </div>
-  </li>
-
-
-  <li class="product-list-item">
-    <div class="offer-container">
-    </div>
-    <div class="link-container">
-      <!-- The link DOES NOT wrap the entire description -->
-      <h3 class="product-heading">
-        <a class="product-link" href="/demos/">
-          <span class="brand">
-            mPhone
-          </span>
-          <span class="product-title">
-            Universe Max Sorta Kinda Phabulous Mark IIVI (Product Green [cash] Edition) 
-          </span>
-        </a>
-      </h3>
-      <div class="product-image-container">
-        <img class="product-image" src="/assets/images/products/mobile-phone.png" alt="mPhone Universe Max Sorta Phabulous"/>
-      </div>
-      <ul id="meta" class="product-meta">
-        <li class="rating">4.8 Stars</li>
-        <li class="network">6G <span class="hidden">network compatibility</span></li>
-      </ul>
-      <div class="end-cap">
-        <ul id="colors" class="product-colors">
-          <li class="red"><span class="hidden">Sunset Red</span></li>
-          <li class="gold"><span class="hidden">Golden Canyon</span></li>
-          <li class="blue"><span class="hidden">Blue</span></li>
-          <li class="gray"><span class="hidden">Graphite</span></li>
-        </ul>
-        <ul id="pricing" class="product-pricing">
-          <li class="monthly">
-            <div><strong>Monthly</strong></div>
-            <strong>
-              $22.00<span class="hidden">,</span>
-            </strong>
-            <span class="hidden">
-              Original price:
-            </span>        
-            <s>$50.00</s>
-            <div>For 36 months</div>
-          </li>
-          <li class="today">
-            <div><strong>Today</strong></div>
-            $0
-            <div>down + tax</div>
-          </li>
-          <li class="full-price">
-            <strong>Full price</strong> $1,789<span class="hidden">,</span>
-            <span class="hidden">
-              Original price:
-            </span>        
-            <s>$1,998</s>
-          </li>
-        </ul>
-        <div class="button" aria-hidden="true">
-          See details
-        </div>
-      </div>
-    </div>
-  </li>
-
-  <li class="product-list-item">
-    <div class="offer-container">
-      <button type="button" class="tertiary" aria-label="Save $400 with offer for mPhone Universe Not So Phabulous">
-        Save $100 with offer
-      </button>
-    </div>
-
-    <div class="link-container">
-      <!-- The link DOES NOT wrap the entire description -->
-      <h3 class="product-heading">
-        <a class="product-link" href="/demos/">
-          <span class="brand">
-            mPhone
-          </span>
-          <span class="product-title">
-            Universe Not So Phabulous
-          </span>
-        </a>
-      </h3>
-      <div class="product-image-container">
-        <img class="product-image" src="/assets/images/products/mobile-phone.png" alt="mPhone Universe Not So Phabulous"/>
-      </div>
-      <ul id="meta" class="product-meta">
-        <li class="rating">4.8 Stars</li>
-        <li class="network">2G <span class="hidden">network compatibility</span></li>
       </ul>
       <div class="end-cap">
         <ul id="colors" class="product-colors">

--- a/_includes/examples/product.html
+++ b/_includes/examples/product.html
@@ -70,7 +70,7 @@
 
 <h2 class="h-bravo">Product Card with multiple controls</h2>
 <p>This example demonstrates an approach taken for when the card may have multiple controls within it. This pattern was inspired by <a href="https://inclusive-components.design/cards/">Inclusive Components: Cards</a>.</p>
-<p><strong>Note:</strong> This approach works well for screen reader users but introduces challenges for voice recognition users because the fake "See Details" button is hidden from assistive technology. Additionally, this pattern introduces barriers for text-to-speech users because text selection with the mouse in the card is difficult.</p>
+<p><strong>Note:</strong> This approach works well for screen reader users but introduces challenges for voice recognition users because the fake "See Details" button is hidden from assistive technology. Additionally, this pattern introduces barriers for text-to-speech users because text selection with the mouse within the card is difficult.</p>
 <ul class="product-list multiple-controls">
   <li class="product-list-item">
     <div class="offer-container">

--- a/_sass/modules/_product.scss
+++ b/_sass/modules/_product.scss
@@ -13,7 +13,7 @@
     grid-template-columns: 1fr 1fr 1fr;  
   }
 
-  .offer-container {
+  &.multiple-controls .offer-container {
     display: grid;
     min-height: 4rem;
     align-self: start;
@@ -36,6 +36,7 @@
     list-style-type: none;
     transition: .8s;
     align-items: start;
+    min-width: 280px;
 
     @include float;
     
@@ -175,7 +176,7 @@
   li {
     list-style-type: none;
     display: block;
-    padding: .25rem .5rem;
+    padding: .25rem .5rem !important;
     margin: 0;
     background: #fff;
     border-radius: 2px;
@@ -187,5 +188,25 @@
       color: #fff;
       background: $color-gray-dark;
     }
+  }
+}
+
+
+.big-links {
+  .product-list-item {
+    padding: 0 !important;
+  }
+  a {
+    text-decoration: inherit;
+    padding: 1em;
+    border-radius: 1rem;
+    box-shadow: 0 0.5rem 0.75rem 0 rgba(0, 0, 0, 0.04), 0 0 1rem 0 rgba(204, 204, 204, 0.08);
+  }
+  &.product-list .product-list-item {
+    grid-template-rows: auto;
+  }
+  .product-title,.offer-container {
+    margin-bottom: 1em;
+    display: block;
   }
 }

--- a/_sass/modules/_syntax-highlighting.scss
+++ b/_sass/modules/_syntax-highlighting.scss
@@ -38,6 +38,19 @@ pre {
   }
   &.bad-example {
     position: relative;
+    margin-top: 1em;
+    &::before {
+      content: "Bad example";
+      position: absolute;
+      top: -21px;
+      right: 0;
+      background: firebrick;
+      color: #fff;
+      padding: 3px 10px;
+      font-size: .7em;
+      border-top-left-radius: 3px;
+      border-top-right-radius: 3px;
+    }
     &::after {
       content: '';
       display: block;
@@ -49,7 +62,6 @@ pre {
       background-image:url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAAHElEQVQYV2P4//+/FBbMgI4ZhohCbBhD81BQCAD6ay/4Sj20ZAAAAABJRU5ErkJggg==);
     }
   }
-
 
   .c     { color: #676767; font-style: italic } // Comment
   .err   { color: #a61717; background-color: #e3d2d2 } // Error


### PR DESCRIPTION
Added a new single-link product card (driven by `aria-labelledby` and `aria-describedby`) to the Product Card example page and some accessibility barrier notes about the pre-existing card example (which feels like an [Inclusive Components Card](https://inclusive-components.design/cards/) hybrid) because it presents WCAG 2.5.3 Label in Name issues as well as text-to-speech barriers.