### PR TITLE
updating content found related to AC review

### DIFF
--- a/_checklist-native/animation.md
+++ b/_checklist-native/animation.md
@@ -29,7 +29,7 @@ settings:
 ## Developer notes
 - A non-interactive animation is a technique by which still images are manipulated to create moving images 
 - Animations can affect users with motion disabilities.  Guidance is to keep animations to 5 seconds or less
-- Animations that flash can also have a deadly affect to users with epilepsy.  Guidance is to keep flashing to 3 seconds per second
+- Animations that flash can also have a deadly affect to users with epilepsy.  Guidance is to keep flashing to no more than 3 times per second
 - Ensure animations that are meaningful have alt text assigned
 - Animations cannot stop and start again unless screen is refreshed or similar
 - If a stop/pause button next to the animation is provided, the animation can run more than 5 seconds
@@ -75,7 +75,7 @@ settings:
 ## Developer notes
 - A non-interactive animation is a technique by which still images are manipulated to create moving images 
 - Animations can affect users with motion disabilities.  Guidance is to keep animations to 5 seconds or less
-- Animations that flash can also have a deadly affect to users with epilepsy.  Guidance is to keep flashing to 3 seconds per second
+- Animations that flash can also have a deadly affect to users with epilepsy.  Guidance is to keep flashing to no more than 3 times per second
 - Ensure animations that are meaningful have alt text assigned
 - Animations cannot stop and start again unless screen is refreshed or similar
 - If a stop/pause button next to the animation is provided, the animation can run more than 5 seconds

--- a/_checklist-native/segmented-control.md
+++ b/_checklist-native/segmented-control.md
@@ -34,7 +34,9 @@ settings:
     This element is exempt from text resizing requirements
 ---
 
-## Developer notes
+## iOS
+
+### Developer notes
 
 - A segmented control is a horizontal set of two or more segments presented, each of which functions as a mutually exclusive button
 - Once a tab has been selected, the focus should remain in the tab group on the selected tab.  The user swipes through the tab group and the content revealed by the tab action should be the first swipe out of the tab group.

--- a/_checklist-native/sidebar-menu.md
+++ b/_checklist-native/sidebar-menu.md
@@ -11,12 +11,18 @@ keyboard:
     Activates on iOS and Android
   enter: |
     Activates on Android
+  if close button present: |
+    Activate the close button and focus should return to the triggering element
           
 mobile:
   swipe: |
     Focus moves to the element, expresses its name, role (state, if applicable)
   doubletap: |
     Activates the menu item
+  Two-finger swipe to the left anywhere on the screen closes the menu: |
+    Activates close on Android
+  if close button present: |
+    Double tap to activate the close button and focus should return to the triggering element
     
 screenreader: 
   name:  |

--- a/_checklist-native/sidebar-menu.md
+++ b/_checklist-native/sidebar-menu.md
@@ -164,7 +164,7 @@ settings:
   - Use `DrawerLayout` with two child views: a `NavHostFragment` to contain the main content and a `NavigationView` for the contents of the navigation drawer
 
 - **Jetpack Compose**
-  - Use 1ModalNavigationDrawer` composable
+  - Use `ModalNavigationDrawer` composable
 
 
 ### Groupings


### PR DESCRIPTION
Included two updates to (1) animations to change "seconds per second" to "no more than 3 flashes per second" under both iOS and Android developer notes and (2) segmented controls to bring back the iOS heading that went missing historically. 