### PR TITLE
updated KB and mobile screen reader announcement-no focus

### DIFF
--- a/_checklist-native/snackbar-toast.md
+++ b/_checklist-native/snackbar-toast.md
@@ -11,7 +11,7 @@ keyboard:
   enter: |
     Any elements inside are activated on Android
   When no interactive element is in the snackbar: |
-    Dynamically announced, without moving focus to it
+    The snackbar/toast is dynamically announced, without moving focus to it
 
 mobile:
   swipe: |
@@ -19,7 +19,7 @@ mobile:
   doubletap: |
     Activates any interactive elements within the snackbar
   When no interactive element is in the snackbar: |
-    Dynamically announced, without moving focus to it
+    The snackbar/toast is dynamically announced, without moving focus to it
 
 screenreader:
   name:  |

--- a/_checklist-native/snackbar-toast.md
+++ b/_checklist-native/snackbar-toast.md
@@ -10,12 +10,16 @@ keyboard:
     Any elements inside are activated on iOS and Android
   enter: |
     Any elements inside are activated on Android
+  When no interactive element is in the snackbar: |
+    Dynamically announced, without moving focus to it
 
 mobile:
   swipe: |
     Focus moves within the snackbar
   doubletap: |
     Activates any interactive elements within the snackbar
+  When no interactive element is in the snackbar: |
+    Dynamically announced, without moving focus to it
 
 screenreader:
   name:  |


### PR DESCRIPTION
Updated Snackbar/Toast keyboard and mobile screen reader acceptance criteria for announcement and not moving focus.