### PR TITLE
Add link wcag criteria within Further Reading section

### DIFF
--- a/_checklist-web/link.md
+++ b/_checklist-web/link.md
@@ -225,4 +225,5 @@ Sometimes the design will call for multiple links with the same text label. In a
 - [WCAG 1.4.1 Use of Color (Level A)](https://www.w3.org/WAI/WCAG22/Understanding/use-of-color)
 - [WCAG 2.1.1 Keyboard (Level A)](https://www.w3.org/WAI/WCAG22/Understanding/keyboard)
 - [WCAG 2.4.4 Link Purpose (In Context) (Level A)](https://www.w3.org/WAI/WCAG22/Understanding/link-purpose-in-context.html)
+- [WCAG 2.5.3 Label in Name (Level A)](https://www.w3.org/WAI/WCAG22/Understanding/label-in-name.html)
 - [WCAG 4.1.2 Name, Role, Value (Level A)](https://www.w3.org/WAI/WCAG22/Understanding/name-role-value)

--- a/_checklist-web/link.md
+++ b/_checklist-web/link.md
@@ -220,3 +220,9 @@ Sometimes the design will call for multiple links with the same text label. In a
 {% highlight html %}
 {% include /examples/product.html %}
 {% endhighlight %}
+
+## Further Reading
+- [WCAG 1.4.1 Use of Color (Level A)](https://www.w3.org/WAI/WCAG22/Understanding/use-of-color)
+- [WCAG 2.1.1 Keyboard (Level A)](https://www.w3.org/WAI/WCAG22/Understanding/keyboard)
+- [WCAG 2.4.4 Link Purpose (In Context) (Level A)](https://www.w3.org/WAI/WCAG22/Understanding/link-purpose-in-context.html)
+- [WCAG 4.1.2 Name, Role, Value (Level A)](https://www.w3.org/WAI/WCAG22/Understanding/name-role-value)


### PR DESCRIPTION
Note:
Considered adding 1.4.3 and 2.4.7 but tried to limit the number of criteria to no more than four.

To review:
See the very bottom of the page for added "Further Reading" section and WCAG links.