### PR TITLE
Fix rtl star input order

### DIFF
--- a/_includes/examples/input-stars.html
+++ b/_includes/examples/input-stars.html
@@ -3,25 +3,25 @@
     Rate this product
   </legend>
   <div class="star-rating">
-    <input type="radio" class="star" name="star" id="star-5">
-    <label for="star-5">
-      <span class="hidden">5 star</span>
-    </label>
-    <input type="radio" class="star" name="star" id="star-4">
-    <label for="star-4">
-      <span class="hidden">4 star</span>
-    </label>
-    <input type="radio" class="star" name="star" id="star-3">
-    <label for="star-3">
-      <span class="hidden">3 star</span>
+    <input type="radio" class="star" name="star" id="star-1">
+    <label for="star-1">
+      <span class="hidden">1 star</span>
     </label>
     <input type="radio" class="star" name="star" id="star-2">
     <label for="star-2">
       <span class="hidden">2 star</span>
     </label>
-    <input type="radio" class="star" name="star" id="star-1">
-    <label for="star-1">
-      <span class="hidden">1 star</span>
+    <input type="radio" class="star" name="star" id="star-3">
+    <label for="star-3">
+      <span class="hidden">3 star</span>
+    </label>
+    <input type="radio" class="star" name="star" id="star-4">
+    <label for="star-4">
+      <span class="hidden">4 star</span>
+    </label>
+    <input type="radio" class="star" name="star" id="star-5">
+    <label for="star-5">
+      <span class="hidden">5 star</span>
     </label>
   </div>
 </fieldset>

--- a/_sass/modules/_star-rating.scss
+++ b/_sass/modules/_star-rating.scss
@@ -43,7 +43,6 @@
 
 
 .star-rating {
-  direction: rtl;
   display: grid;
   grid-template-columns: repeat(5, 1fr);
 }


### PR DESCRIPTION
Reordered the star numbering within the html and removed rtl in the CSS. 