### PR TITLE
Fix documentation URLs and remove V2 references

### DIFF
--- a/public/content/documentation/MARKDOWN_GUIDE.md
+++ b/public/content/documentation/MARKDOWN_GUIDE.md
@@ -1,8 +1,8 @@
-# 📘 Markdown Guide for MagentaA11y V2
+# 📘 Markdown Guide for MagentaA11y
 
-This guide outlines how to structure and write Markdown files consumed by the MagentaA11y V2 app.
+This guide outlines how to structure and write Markdown files consumed by the MagentaA11y app.
 
-🛠️ New Markdown files can be generated via: `src/scripts/createMarkdown.sh`  
+🛠️ New Markdown files can be generated via: `src/scripts/createMarkdown.sh`
 Run the script using:
 
 ```bash
@@ -107,7 +107,7 @@ You can use custom HTML elements with attributes to enhance interactivity:
 Relative paths are resolved based on:
 
 ```
-/MagentaA11yV2/content/assets
+/MagentaA11y/content/assets
 ```
 
 ---

--- a/readme.md
+++ b/readme.md
@@ -168,7 +168,7 @@ The app is deployed via GitHub Pages. Follow these steps to deploy:
    https://<username>.github.io/<repository-name>
    ```
 
-   https://tmobile.github.io/magentaA11y
+   https://www.magentaa11y.com/
 
 ---
 

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-# MagentaA11y V2
+# MagentaA11y
 
 ## Table of Contents
 
@@ -22,8 +22,8 @@
 To set up the application, clone the repository and install dependencies:
 
 ```bash
-git clone https://github.com/KArbeRes/MagentaA11yV2.git
-cd MagentaA11yV2
+git clone https://github.com/tmobile/magentaA11y.git
+cd magentaA11y
 npm install
 ```
 
@@ -113,7 +113,7 @@ npm run create-md -- textarea "native/controls" criteria
 npm run create-md -- "images" "how-to-test/components" how-to-test
 ```
 
-> 🗂️ When running the `create-md` script, files are saved to the `public/content/documentation` directory.  
+> 🗂️ When running the `create-md` script, files are saved to the `public/content/documentation` directory.
 > The relative path you provide is resolved within this base directory.
 
 ### Markdown File Structure
@@ -168,7 +168,7 @@ The app is deployed via GitHub Pages. Follow these steps to deploy:
    https://<username>.github.io/<repository-name>
    ```
 
-   https://karberes.github.io/MagentaA11yV2/#/home
+   https://tmobile.github.io/magentaA11y
 
 ---
 


### PR DESCRIPTION
- Update repo URL from KArbeRes/MagentaA11yV2 to tmobile/magentaA11y in Installation section
- Update deployment URL to tmobile.github.io/magentaA11y
- Remove V2 references in README title and MARKDOWN_GUIDE.md title and description

Fixes #264