### PR TITLE
feat: add search for criteria and how to pages using Fuse JS package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@types/react": "^18.3.11",
         "@types/react-dom": "^18.3.0",
         "classnames": "^2.5.1",
+        "fuse.js": "^7.4.1",
         "graphql": "^16.9.0",
         "highlight.js": "^11.10.0",
         "lit": "^3.2.1",
@@ -10542,6 +10543,19 @@
       "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/fuse.js": {
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-7.4.1.tgz",
+      "integrity": "sha512-AY7lKAXK71hi3WgUvDy6oZL67UEHOOtvCAwVdOXHyJd6ZzftBy7QqxuXt4HxmmAhYjmp/YCuOELZtIvAdlZ+fw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/krisk"
       }
     },
     "node_modules/gensync": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@types/react": "^18.3.11",
     "@types/react-dom": "^18.3.0",
     "classnames": "^2.5.1",
+    "fuse.js": "^7.4.1",
     "graphql": "^16.9.0",
     "highlight.js": "^11.10.0",
     "lit": "^3.2.1",

--- a/src/components/content-display/content-display.tsx
+++ b/src/components/content-display/content-display.tsx
@@ -7,6 +7,7 @@ import Button from 'components/custom-components/buttons/button/button';
 import { useClipboard } from 'hooks/useClipboard';
 import { useContentTabs } from 'hooks/useContentTabs';
 import { useCriteriaManager } from 'hooks/useCriteriaManager';
+import { useSearch } from 'hooks/useSearch';
 import React, { useEffect, useRef } from 'react';
 import { useLocation, useNavigate, useSearchParams } from 'react-router-dom';
 import { Icons } from 'shared/Icons';
@@ -16,7 +17,7 @@ import Cards from '../custom-components/cards/cards';
 import { SideNavItem } from '../navigation/nav.types';
 import MarkdownContent from './markdown-content/markdown-content';
 import { Criteria } from './markdown-content/markdown-content.types';
-
+import SearchBar from '../custom-components/search/search';
 import Breadcrumb from '../breadcrumb/breadcrumb';
 import { useBreadcrumbs } from 'hooks/useBreadcrumbs';
 import '../../styles/_code-blocks.scss';
@@ -35,7 +36,7 @@ const ContentDisplay: React.FC<ContentDisplayProps> = ({
   items,
   onToggleSideNav,
 }) => {
-  const [searchParams] = useSearchParams();
+  const [pageParams] = useSearchParams();
   const navigate = useNavigate();
   const location = useLocation();
   const tabsRef = useRef<HTMLElement>(null);
@@ -52,10 +53,12 @@ const ContentDisplay: React.FC<ContentDisplayProps> = ({
 
   const breadcrumbs = useBreadcrumbs(documentation, items);
 
+  const { query, setQuery, results } = useSearch(currentItem?.children ?? []);
+
   useEffect(() => {
     if (!tabs.length) return;
 
-    const tabFromURL = searchParams.get('tab');
+    const tabFromURL = pageParams.get('tab');
     if (tabFromURL) {
       const tabIndex = parseInt(tabFromURL, 10);
       if (!isNaN(tabIndex) && tabIndex >= 0 && tabIndex < tabs.length) {
@@ -64,10 +67,10 @@ const ContentDisplay: React.FC<ContentDisplayProps> = ({
     } else {
       setActiveTab(0);
     }
-  }, [searchParams, setActiveTab, tabs.length]);
+  }, [pageParams, setActiveTab, tabs.length]);
 
   useEffect(() => {
-    const tabFromURL = searchParams.get('tab');
+    const tabFromURL = pageParams.get('tab');
     if (tabFromURL) {
       const tabIndex = parseInt(tabFromURL, 10);
       if (!isNaN(tabIndex) && tabIndex >= 0 && tabIndex < tabs.length) {
@@ -76,7 +79,7 @@ const ContentDisplay: React.FC<ContentDisplayProps> = ({
     } else {
       setActiveTab(0);
     }
-  }, [searchParams, setActiveTab, tabs.length]);
+  }, [pageParams, setActiveTab, tabs.length]);
 
   // Track active tab changes
   useEffect(() => {
@@ -106,6 +109,8 @@ const ContentDisplay: React.FC<ContentDisplayProps> = ({
   if (!currentItem) return <div>No content available</div>;
 
   const { label, generalNotes, children } = currentItem;
+  const cardItems = results ?? children; // content to render in overview cards
+  const cardsListId = `overviewCard-${label}`;
 
   let actionsButtonsVisible = Object.values(Criteria).some(
     (criteria) => criteria === tabs[activeTab]?.label
@@ -135,16 +140,20 @@ const ContentDisplay: React.FC<ContentDisplayProps> = ({
           id="criteria-button"></Button>
       </div>
 
-      {isOverviewRoute && children && children.length > 0 && (
-        <Cards
-          items={children.map((child) => ({
-            title: child.label,
-            description: child.generalNotes || undefined,
-            link: `${location.pathname.replace(/\/overview$/, '')}/${
-              child.name
-            }`,
-          }))}
-        />
+      {isOverviewRoute && cardItems && cardItems.length > 0 && (
+        <>
+          <SearchBar controlsId={cardsListId} resultCount={cardItems.length} query={query} onQueryChange={setQuery} />
+          <Cards
+            id={cardsListId}
+            items={cardItems.map((child) => ({
+              title: child.label,
+              description: child.generalNotes || undefined,
+              link: `${location.pathname.replace(/\/overview$/, '')}/${
+                child.name
+              }`,
+            }))}
+          />
+        </>
       )}
 
       {!isOverviewRoute && tabs.length > 0 && (

--- a/src/components/content-display/content-display.tsx
+++ b/src/components/content-display/content-display.tsx
@@ -140,7 +140,7 @@ const ContentDisplay: React.FC<ContentDisplayProps> = ({
           id="criteria-button"></Button>
       </div>
 
-      {isOverviewRoute && cardItems && cardItems.length > 0 && (
+      {isOverviewRoute && cardItems && (
         <>
           <SearchBar controlsId={cardsListId} resultCount={cardItems.length} query={query} onQueryChange={setQuery} />
           <Cards

--- a/src/components/custom-components/cards/cards.tsx
+++ b/src/components/custom-components/cards/cards.tsx
@@ -11,11 +11,12 @@ interface Card {
 
 interface CardsProps {
   items: Card[];
+  id?: string;
 }
 
-const Cards: React.FC<CardsProps> = ({ items }) => {
+const Cards: React.FC<CardsProps> = ({ items, id }) => {
   return (
-    <ul className="MagentaA11y__card" role="list">
+    <ul className="MagentaA11y__card" role="list" id={id}>
       {items.map((item) => (
         <li key={item.link} className="MagentaA11y__card__item" role="listitem">
           <NavLink to={item.link} className="MagentaA11y__card__link">

--- a/src/components/custom-components/cards/cards.tsx
+++ b/src/components/custom-components/cards/cards.tsx
@@ -18,7 +18,7 @@ const Cards: React.FC<CardsProps> = ({ items, id }) => {
   return (
     <ul className="MagentaA11y__card" role="list" id={id}>
       {items.map((item) => {
-        if (item.link === '/how-to-test-criteria/test-type/no-results') return (
+        if (item.link.includes('no-results')) return (
           <h2>No results found.</h2>
         );
         return (

--- a/src/components/custom-components/cards/cards.tsx
+++ b/src/components/custom-components/cards/cards.tsx
@@ -17,7 +17,11 @@ interface CardsProps {
 const Cards: React.FC<CardsProps> = ({ items, id }) => {
   return (
     <ul className="MagentaA11y__card" role="list" id={id}>
-      {items.map((item) => (
+      {items.map((item) => {
+        if (item.link === '/how-to-test-criteria/test-type/no-results') return (
+          <h2>No results found.</h2>
+        );
+        return (
         <li key={item.link} className="MagentaA11y__card__item" role="listitem">
           <NavLink to={item.link} className="MagentaA11y__card__link">
             <h2 className="MagentaA11y__card__title">{item.title}</h2>
@@ -29,6 +33,8 @@ const Cards: React.FC<CardsProps> = ({ items, id }) => {
             <svg
               width="24"
               height="24"
+              aria-hidden="true"
+              focusable="false"
               viewBox="0 0 24 24"
               fill="none"
               xmlns="http://www.w3.org/2000/svg">
@@ -39,7 +45,8 @@ const Cards: React.FC<CardsProps> = ({ items, id }) => {
             </svg>
           </NavLink>
         </li>
-      ))}
+        );
+      })}
     </ul>
   );
 };

--- a/src/components/custom-components/cards/cards.tsx
+++ b/src/components/custom-components/cards/cards.tsx
@@ -17,36 +17,41 @@ interface CardsProps {
 const Cards: React.FC<CardsProps> = ({ items, id }) => {
   return (
     <ul className="MagentaA11y__card" role="list" id={id}>
-      {items.map((item) => {
-        if (item.link.includes('no-results')) return (
-          <h2>No results found.</h2>
-        );
-        return (
-        <li key={item.link} className="MagentaA11y__card__item" role="listitem">
-          <NavLink to={item.link} className="MagentaA11y__card__link">
-            <h2 className="MagentaA11y__card__title">{item.title}</h2>
-            {item.description && (
-              <span className="MagentaA11y__card__description">
-                {item.description}
-              </span>
-            )}
-            <svg
-              width="24"
-              height="24"
-              aria-hidden="true"
-              focusable="false"
-              viewBox="0 0 24 24"
-              fill="none"
-              xmlns="http://www.w3.org/2000/svg">
-              <path
-                d="M12 19.6155L10.9308 18.5616L16.7424 12.7501H4.38465V11.2501H16.7424L10.9308 5.43859L12 4.38477L19.6154 12.0001L12 19.6155Z"
-                fill="#121212"
-              />
-            </svg>
-          </NavLink>
+      {items && items.length > 0 ? (
+        items.map((item) => {
+          return (
+          <li key={item.link} className="MagentaA11y__card__item" role="listitem">
+            <NavLink to={item.link} className="MagentaA11y__card__link">
+              <h2 className="MagentaA11y__card__title">{item.title}</h2>
+              {item.description && (
+                <span className="MagentaA11y__card__description">
+                  {item.description}
+                </span>
+              )}
+              <svg
+                width="24"
+                height="24"
+                aria-hidden="true"
+                focusable="false"
+                viewBox="0 0 24 24"
+                fill="none"
+                xmlns="http://www.w3.org/2000/svg">
+                <path
+                  d="M12 19.6155L10.9308 18.5616L16.7424 12.7501H4.38465V11.2501H16.7424L10.9308 5.43859L12 4.38477L19.6154 12.0001L12 19.6155Z"
+                  fill="#121212"
+                />
+              </svg>
+            </NavLink>
+          </li>
+          );
+        })
+      ) : (
+        <li className="MagentaA11y__card__item" role="listitem">
+          <div className="MagentaA11y__card__link">
+            <h2 className="MagentaA11y__card__title">No results found.</h2>
+          </div>
         </li>
-        );
-      })}
+      )}
     </ul>
   );
 };

--- a/src/components/custom-components/search/search.scss
+++ b/src/components/custom-components/search/search.scss
@@ -1,0 +1,19 @@
+.searchbar {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+
+    &__label {
+        margin-right: 1rem;
+        font: var(--magentaa11y-typeset-body-xl-strong);
+    }
+
+    &__input {
+        height: 50px;
+        flex-grow: 1;
+        border-color: var(--color-text-link);
+        border-radius: 25px;
+        font: var(--magentaa11y-typeset-body-lg-normal);
+        padding: 0 1rem;
+    }
+}

--- a/src/components/custom-components/search/search.scss
+++ b/src/components/custom-components/search/search.scss
@@ -15,5 +15,9 @@
         border-radius: 25px;
         font: var(--magentaa11y-typeset-body-lg-normal);
         padding: 0 1rem;
+
+        &:focus-visible {
+           outline-offset: -5px;
+        }
     }
 }

--- a/src/components/custom-components/search/search.tsx
+++ b/src/components/custom-components/search/search.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import './search.scss';
+
+interface SearchBarProps {
+  controlsId: string;
+  resultCount: number;
+  query: string;
+  onQueryChange: (query: string) => void;
+}
+
+const SearchBar: React.FC<SearchBarProps> = ({ controlsId, resultCount, query, onQueryChange }) => {
+  return (
+    <div className="searchbar">
+      <label htmlFor="search1" className="searchbar__label">
+          Search to filter the cards:
+      </label>
+      <input
+        className="searchbar__input"
+        role="combobox"
+        aria-autocomplete="list"
+        id="search1"
+        type="search"
+        value={query}
+        onChange={(e) => onQueryChange(e.target.value)}
+        aria-controls={controlsId}
+        aria-expanded="false"
+        aria-haspopup="false"
+      />
+      <span className="hidden-visually" role="status">
+        {query ? `${resultCount} result${resultCount !== 1 ? 's' : ''} found` : ''}
+      </span>
+    </div>
+  );
+};
+
+export default SearchBar;

--- a/src/components/custom-components/search/search.tsx
+++ b/src/components/custom-components/search/search.tsx
@@ -11,14 +11,14 @@ interface SearchBarProps {
 const SearchBar: React.FC<SearchBarProps> = ({ controlsId, resultCount, query, onQueryChange }) => {
   return (
     <div className="searchbar">
-      <label htmlFor="search1" className="searchbar__label">
+      <label htmlFor="criteriaSearch" className="searchbar__label">
           Search to filter the cards:
       </label>
       <input
         className="searchbar__input"
         role="combobox"
         aria-autocomplete="list"
-        id="search1"
+        id="criteriaSearch"
         type="search"
         value={query}
         onChange={(e) => onQueryChange(e.target.value)}

--- a/src/components/custom-components/search/search.tsx
+++ b/src/components/custom-components/search/search.tsx
@@ -5,7 +5,7 @@ interface SearchBarProps {
   controlsId: string;
   resultCount: number;
   query: string;
-  onQueryChange: (query: string) => void;
+  onQueryChange: (q: string) => void;
 }
 
 const SearchBar: React.FC<SearchBarProps> = ({ controlsId, resultCount, query, onQueryChange }) => {
@@ -21,7 +21,7 @@ const SearchBar: React.FC<SearchBarProps> = ({ controlsId, resultCount, query, o
         id="criteriaSearch"
         type="search"
         value={query}
-        onChange={(e) => onQueryChange(e.target.value)}
+        onChange={(e) => onQueryChange(e.target.value)} // returns new value to setQuery in hook
         aria-controls={controlsId}
         aria-expanded="false"
         aria-haspopup="false"

--- a/src/components/custom-components/search/search.tsx
+++ b/src/components/custom-components/search/search.tsx
@@ -9,24 +9,20 @@ interface SearchBarProps {
 }
 
 const SearchBar: React.FC<SearchBarProps> = ({ controlsId, resultCount, query, onQueryChange }) => {
-  const resultsString = resultCount === 1 ? 'No results found' : `${resultCount} result${resultCount !== 1 ? 's' : ''} found`;
+  const resultsString = resultCount === 0 ? 'No results found' : `${resultCount} result${resultCount !== 1 ? 's' : ''} found`;
 
   return (
-    <div className="searchbar">
+    <div className="searchbar" role="search">
       <label htmlFor="criteriaSearch" className="searchbar__label">
           Search to filter:
       </label>
       <input
         className="searchbar__input"
-        role="combobox"
-        aria-autocomplete="list"
         id="criteriaSearch"
         type="search"
         value={query}
         onChange={(e) => onQueryChange(e.target.value)} // returns new value to setQuery in hook
         aria-controls={controlsId}
-        aria-expanded="false"
-        aria-haspopup="false"
       />
       <span className="hidden-visually" role="status">
         {resultsString}

--- a/src/components/custom-components/search/search.tsx
+++ b/src/components/custom-components/search/search.tsx
@@ -9,10 +9,12 @@ interface SearchBarProps {
 }
 
 const SearchBar: React.FC<SearchBarProps> = ({ controlsId, resultCount, query, onQueryChange }) => {
+  const resultsString = resultCount === 1 ? 'No results found' : `${resultCount} result${resultCount !== 1 ? 's' : ''} found`;
+
   return (
     <div className="searchbar">
       <label htmlFor="criteriaSearch" className="searchbar__label">
-          Search to filter the cards:
+          Search to filter:
       </label>
       <input
         className="searchbar__input"
@@ -27,7 +29,7 @@ const SearchBar: React.FC<SearchBarProps> = ({ controlsId, resultCount, query, o
         aria-haspopup="false"
       />
       <span className="hidden-visually" role="status">
-        {query ? `${resultCount} result${resultCount !== 1 ? 's' : ''} found` : ''}
+        {resultsString}
       </span>
     </div>
   );

--- a/src/hooks/useSearch.ts
+++ b/src/hooks/useSearch.ts
@@ -9,7 +9,7 @@ interface ContentItem {
 }
 
 export const useSearch = (items: ContentItem[]) => {
-  const [query, setQuery] = useState('');
+  const [query, setQuery] = useState(''); // start with query being ''
 
   const fuse = useMemo(
     () =>

--- a/src/hooks/useSearch.ts
+++ b/src/hooks/useSearch.ts
@@ -1,0 +1,31 @@
+import { useMemo, useState } from 'react';
+import Fuse from 'fuse.js';
+
+interface ContentItem {
+  label: string;
+  name: string;
+  generalNotes?: string | null;
+  developerNotes?: string | null;
+}
+
+export const useSearch = (items: ContentItem[]) => {
+  const [query, setQuery] = useState('');
+
+  const fuse = useMemo(
+    () =>
+      new Fuse(items, {
+        keys: ['label', 'developerNotes', 'generalNotes'],
+        threshold: 0.2,
+        useTokenSearch: true, // can remove for fuzzier search, but it's kind of nice
+        includeScore: true,
+      }),
+    [items]
+  );
+
+  const matches = query ? fuse.search(query).map((r) => r.item) : null;
+  const results = matches && matches.length === 0
+    ? [{ label: 'No results found', name: 'no-results', generalNotes: "No criteria matches this search."}]
+    : matches;
+
+  return { query, setQuery, results };
+};

--- a/src/hooks/useSearch.ts
+++ b/src/hooks/useSearch.ts
@@ -16,7 +16,7 @@ export const useSearch = (items: ContentItem[]) => {
       new Fuse(items, {
         keys: ['label', 'developerNotes', 'generalNotes'],
         threshold: 0.2,
-        useTokenSearch: true, // can remove for fuzzier search, but it's kind of nice
+        // useTokenSearch: true, // can add in fuzzier search .. or perhaps toggle this at some point for pro folks who want to search "card" or "aria-busy" etc
         includeScore: true,
       }),
     [items]

--- a/src/hooks/useSearch.ts
+++ b/src/hooks/useSearch.ts
@@ -23,9 +23,7 @@ export const useSearch = (items: ContentItem[]) => {
   );
 
   const matches = query ? fuse.search(query).map((r) => r.item) : null;
-  const results = matches && matches.length === 0
-    ? [{ label: 'No results found', name: 'no-results', generalNotes: "No criteria matches this search."}]
-    : matches;
+  const results = matches;
 
   return { query, setQuery, results };
 };

--- a/src/hooks/useSearch.ts
+++ b/src/hooks/useSearch.ts
@@ -15,7 +15,7 @@ export const useSearch = (items: ContentItem[]) => {
     () =>
       new Fuse(items, {
         keys: ['label', 'developerNotes', 'generalNotes'],
-        threshold: 0.2,
+        threshold: 0.3,
         // useTokenSearch: true, // can add in fuzzier search .. or perhaps toggle this at some point for pro folks who want to search "card" or "aria-busy" etc
         includeScore: true,
       }),


### PR DESCRIPTION
- enables token searching... so you could just search for "Alert", but will also allow you to search for "aria-busy" or "card" or anything that might be in the dev notes!!
- includes a new hook useSearch to use FuseJS matching: https://www.fusejs.io/token-search.html
- includes new component called searchBar that is added to all overview pages for web, native, and how to
--

things to discuss:
- state doesn't update between pages, is that ok?

--
Claude code was used to help generate code.