### PR TITLE
feat: replace hash routing with BrowserRouter

### DIFF
--- a/check-routes.js
+++ b/check-routes.js
@@ -1,0 +1,111 @@
+/*
+  Checks every URL the site should serve, against the local server.
+
+  Builds its own list from src/shared/content.json and src/utils/path-mapping.ts,
+  so it cannot drift from the real routes and nobody has to maintain a list.
+
+  Usage:
+    node serve-pages.js      (in one terminal, leave running)
+    node check-routes.js     (in another)
+    (or BASE=http://localhost:3001 node check-routes.js if you changed the port)
+
+  A pass means the server returned the app shell, so the page will boot and
+  route. It does not prove React rendered the right component, so also work
+  through the MANUAL list printed at the end.
+
+  This file is for local testing only.
+*/
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const BASE = process.env.BASE || 'http://localhost:3000';
+
+// ---------- build the route list ----------
+const content = JSON.parse(
+  fs.readFileSync(path.join(__dirname, 'src/shared/content.json'), 'utf8')
+);
+
+const contentRoutes = [];
+for (const [section, items] of Object.entries(content)) {
+  for (const cat of items) {
+    contentRoutes.push(`/${section}-criteria/${cat.name}/overview`);
+    for (const child of cat.children || []) {
+      contentRoutes.push(`/${section}-criteria/${cat.name}/${child.name}`);
+    }
+  }
+}
+
+const staticRoutes = [
+  '/',
+  '/home',
+  '/about-us',
+  '/my-criteria',
+  '/basic-accessible-webpage',
+  '/basic-inaccessible-webpage',
+];
+
+const mappingSrc = fs.readFileSync(
+  path.join(__dirname, 'src/utils/path-mapping.ts'),
+  'utf8'
+);
+const legacyRoutes = [
+  ...new Set([...mappingSrc.matchAll(/["'](\/[^"']+)["']\s*:/g)].map((m) => m[1])),
+].filter((p) => p !== '/your-old-path');
+
+const pass = [];
+const fail = [];
+
+async function check(url, label) {
+  try {
+    const res = await fetch(BASE + url, { redirect: 'manual' });
+    // 200 = a real file was served.
+    // 404 = 404.html was served, which is the expected fallback and is exactly
+    //       what production does. Both mean the app boots and routes.
+    const okStatus = res.status === 200 || res.status === 404;
+    const body = await res.text();
+    const isShell =
+      body.includes('<div id="root"') || body.includes('pathSegmentsToKeep');
+    if (okStatus && isShell) {
+      pass.push(`${label} ${url}`);
+    } else {
+      fail.push(`${label} ${url}   status=${res.status} shell=${isShell}`);
+    }
+  } catch (e) {
+    fail.push(`${label} ${url}   ERROR ${e.message}`);
+  }
+}
+
+console.log(`Checking ${BASE}\n`);
+
+for (const r of staticRoutes) await check(r, '[static] ');
+for (const r of contentRoutes) await check(r, '[content]');
+for (const r of legacyRoutes) await check(r, '[legacy] ');
+await check('/web-criteria/component/button?tab=1', '[query]  ');
+
+console.log(`Passed: ${pass.length}`);
+console.log(`Failed: ${fail.length}\n`);
+
+if (fail.length) {
+  console.log('FAILURES');
+  fail.forEach((f) => console.log('  ' + f));
+  console.log('');
+}
+
+const amp = contentRoutes.filter((r) => r.includes('&'));
+console.log('MANUAL CHECKS, open these in a browser:\n');
+console.log('  Ampersand paths, page loads and URL stays intact:');
+amp.forEach((r) => console.log(`    ${BASE}${r}`));
+console.log('\n  Legacy hash URLs, should rewrite to a clean path:');
+console.log(`    ${BASE}/#/web-criteria/component/button`);
+console.log(`    ${BASE}/#/native-criteria/controls/button`);
+console.log('\n  Query preserved through a hash URL, should keep tab=1:');
+console.log(`    ${BASE}/#/web-criteria/component/button?tab=1`);
+console.log('\n  In-page anchor, address bar should update and focus should move:');
+console.log(`    ${BASE}/web-criteria/component/footnote`);
+console.log('\n  Invalid URL, the app NotFound page should render:');
+console.log(`    ${BASE}/this-route-does-not-exist`);
+console.log('\n  Then navigate a few pages and test back and forward.\n');
+
+process.exit(fail.length ? 1 : 0);

--- a/package-lock.json
+++ b/package-lock.json
@@ -106,6 +106,7 @@
       "version": "7.26.9",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.26.9.tgz",
       "integrity": "sha512-lWBYIrF7qK5+GjY5Uy+/hEgp8OJWOD/rpy74GplYRhEauvbHDeFB8t5hPOZxCZ0Oxf4Cc36tK51/l3ymJysrKw==",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.26.2",
@@ -683,6 +684,7 @@
       "version": "7.26.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.26.0.tgz",
       "integrity": "sha512-B+O2DnPc0iG+YXFqOxv2WNuNU97ToWjOomUQ78DouOENWUaM5sVrmet9mcomUGQFwpJd//gvUagXBSdzO1fRKg==",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -1491,6 +1493,7 @@
       "version": "7.25.9",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.25.9.tgz",
       "integrity": "sha512-s5XwpQYCqGerXl+Pu6VDL3x0j2d82eiV77UJ8a2mDHAW7j9SWRqQ2y1fNo1Z74CdcYipl5Z41zvjj4Nfzq36rw==",
+      "peer": true,
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.25.9",
         "@babel/helper-module-imports": "^7.25.9",
@@ -1963,6 +1966,7 @@
           "url": "https://opencollective.com/csstools"
         }
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -1985,6 +1989,7 @@
           "url": "https://opencollective.com/csstools"
         }
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2324,7 +2329,6 @@
       "version": "11.14.0",
       "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.14.0.tgz",
       "integrity": "sha512-L/B1lc/TViYk4DcpGxtAVbx0ZyiKM5ktoIyafGkH6zg/tj+mA+NE//aPYKG0k8kCHSHVJrpLpcAlOBEXQ3SavA==",
-      "peer": true,
       "dependencies": {
         "@emotion/memoize": "^0.9.0",
         "@emotion/sheet": "^1.4.0",
@@ -2390,8 +2394,7 @@
     "node_modules/@emotion/sheet": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.4.0.tgz",
-      "integrity": "sha512-fTBW9/8r2w3dXWYM4HCB1Rdp8NLibOw2+XELH5m5+AkWiL/KqYX6dc0kKYlaYyKjrQ6ds33MCdMPEwgs2z1rqg==",
-      "peer": true
+      "integrity": "sha512-fTBW9/8r2w3dXWYM4HCB1Rdp8NLibOw2+XELH5m5+AkWiL/KqYX6dc0kKYlaYyKjrQ6ds33MCdMPEwgs2z1rqg=="
     },
     "node_modules/@emotion/styled": {
       "version": "11.14.0",
@@ -2436,8 +2439,7 @@
     "node_modules/@emotion/weak-memoize": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.4.0.tgz",
-      "integrity": "sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg==",
-      "peer": true
+      "integrity": "sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg=="
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.28.1",
@@ -3121,9 +3123,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3139,9 +3138,6 @@
       "integrity": "sha512-C0SqjoFKnszqa44EQ7xoaT48nnO0lOyXEULfXMWi8krrjOPGYkeK30Okzla6ATbBYsyZ0ySinK0FVkpv3DwzfQ==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -3159,9 +3155,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3177,9 +3170,6 @@
       "integrity": "sha512-DRWw0mOHusrCCuw2rqP87oLg6PGlkomVDFqw2hIwsSfwWpu4k3XLcBPaKKl6ct/GtL/cwNkgwjV/tc0Mqht3VA==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -3197,9 +3187,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3215,9 +3202,6 @@
       "integrity": "sha512-y9RNUYDe2A1UAdhLyfeOodGRszQdaEoe4nfOpp/sNVPl2CWIcUyFaDoCh4vPLPxu19803j2naLqZup2WxDXCLA==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -3235,9 +3219,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3254,9 +3235,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3272,9 +3250,6 @@
       "integrity": "sha512-VVlpEWwizEFIOom0zdoeKuO5nuTswzVE5uHcBNvHzmeHUpNFajY3HFfbQ+zIH4E2kVaZ/yVxmsShW56TtEy4uA==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -3298,9 +3273,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3322,9 +3294,6 @@
       "integrity": "sha512-N3hzbEpUTJC8pWpPVJvgzGxM+so/MAXc8O2s/53B0LL9ZGpfXpME7Wizkc5d/8fRBlBtkDjzoZGDCqqNDHqLEw==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -3348,9 +3317,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3372,9 +3338,6 @@
       "integrity": "sha512-MYlMiPFiv/EKPAHnp3yNZ9AAWFsxga9c5Bkc6wkar6bqzHLlkGVJHRm0u1ei+VXnZxp3Mz9MG9ZIsI8vSOf3sQ==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -3398,9 +3361,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3423,9 +3383,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3447,9 +3404,6 @@
       "integrity": "sha512-K7ykQ+26Rt6+4BTU80AuGgTPIYX86UxiAKT4rcXX/WNTo7k1ZxpKz+TguHnwVpCqQK3B5PK0vZ0ZBe6nz/ib1w==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -4882,8 +4836,7 @@
     "node_modules/@types/aria-query": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
-      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
-      "peer": true
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw=="
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -5181,6 +5134,7 @@
       "version": "18.3.18",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.18.tgz",
       "integrity": "sha512-t4yC+vtgnkYjNSKlFx1jkAhH8LgTo2N/7Qvi83kdEaUtMDiwpbLAktKDaAMlRcJ5eSxZkH74eEGt1ky31d7kfQ==",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -5190,6 +5144,7 @@
       "version": "18.3.5",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.5.tgz",
       "integrity": "sha512-P4t6saawp+b/dFrUr2cvkVsfvPguwsxtH6dNIYRllMsefqFzkZk5UIjzyDOv5g1dXIPdG4Sp1yCR4Z6RCUsG/Q==",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
@@ -5357,6 +5312,7 @@
       "version": "5.62.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.62.0.tgz",
       "integrity": "sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "5.62.0",
         "@typescript-eslint/types": "5.62.0",
@@ -5719,6 +5675,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5810,6 +5767,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
       "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -6700,6 +6658,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -8901,6 +8860,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz",
       "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -11219,7 +11179,6 @@
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
       "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
-      "peer": true,
       "dependencies": {
         "react-is": "^16.7.0"
       }
@@ -12376,6 +12335,7 @@
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/jest/-/jest-27.5.1.tgz",
       "integrity": "sha512-Yn0mADZB89zTtjkPJEXwrac3LHudkQMR+Paqa8uxJHCBr9agxztUifWCyiYrjhMPBoUVBjyny0I7XH6ozDr7QQ==",
+      "peer": true,
       "dependencies": {
         "@jest/core": "^27.5.1",
         "import-local": "^3.0.2",
@@ -13697,7 +13657,6 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -15456,6 +15415,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.8",
         "picocolors": "^1.1.1",
@@ -16651,6 +16611,7 @@
       "version": "6.1.2",
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
       "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
+      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -17019,6 +16980,7 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -17150,6 +17112,7 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -17198,6 +17161,7 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.11.0.tgz",
       "integrity": "sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A==",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -17799,6 +17763,7 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.80.0.tgz",
       "integrity": "sha512-cIFJOD1DESzpjOBl763Kp1AH7UE/0fcdHe6rZXUdQ9c50uvgigvW97u3IcSeBwOkgqL/PXPBktBCh0KEu5L8XQ==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -17958,6 +17923,7 @@
       "version": "1.85.1",
       "resolved": "https://registry.npmjs.org/sass/-/sass-1.85.1.tgz",
       "integrity": "sha512-Uk8WpxM5v+0cMR0XjX9KfRIacmSG86RH4DCCZjLU2rFh5tyutt9siAXJ7G+YfxQ99Q6wrRMbMlVl6KqUms71ag==",
+      "peer": true,
       "dependencies": {
         "chokidar": "^4.0.0",
         "immutable": "^5.0.2",
@@ -18084,6 +18050,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -19038,6 +19005,7 @@
           "url": "https://github.com/sponsors/stylelint"
         }
       ],
+      "peer": true,
       "dependencies": {
         "@csstools/css-parser-algorithms": "^3.0.4",
         "@csstools/css-tokenizer": "^3.0.3",
@@ -19369,6 +19337,7 @@
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz",
       "integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -20173,6 +20142,7 @@
       "version": "0.21.3",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
       "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -20274,6 +20244,7 @@
       "version": "4.9.5",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
       "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -20712,6 +20683,7 @@
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.105.0.tgz",
       "integrity": "sha512-gX/dMkRQc7QOMzgTe6KsYFM7DxeIONQSui1s0n/0xht36HvrgbxtM1xBlgx596NbpHuQU8P7QpKwrZYwUX48nw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -20781,6 +20753,7 @@
       "version": "4.15.2",
       "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-4.15.2.tgz",
       "integrity": "sha512-0XavAZbNJ5sDrCbkpWL8mia0o5WPOd2YGtxrEiZkBK9FjLppIUK2TgxK6qGD2P3hUXTJNNPVibrerKcx5WkR1g==",
+      "peer": true,
       "dependencies": {
         "@types/bonjour": "^3.5.9",
         "@types/connect-history-api-fallback": "^1.3.5",
@@ -21178,6 +21151,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",

--- a/public/404.html
+++ b/public/404.html
@@ -1,34 +1,39 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
-    <meta charset="UTF-8" />
-    <title>Redirecting...</title>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>MagentaA11y</title>
     <script>
-      // Get the current path (excluding domain, including leading slash)
-      const currentPath = window.location.pathname;
+      /*
+        Single Page Apps for GitHub Pages
+        https://github.com/rafgraph/spa-github-pages
 
-      if (!window.location.hash) {
-        // Check if MagentaA11yV2 is in the path
-        if (currentPath.includes("MagentaA11yV2")) {
-          // Split the path at MagentaA11yV2
-          const pathParts = currentPath.split("MagentaA11yV2");
-          // Take everything after MagentaA11yV2 as the hash route
-          const hashPath = pathParts[1] || "/";
+        GitHub Pages serves this file for any path that is not a real file.
+        It encodes the requested path into a query string and redirects to the
+        site root, where the decoder in index.html restores the real URL.
 
-          // Redirect to MagentaA11yV2 with the rest as hash
-          window.location.replace("/MagentaA11yV2/#" + hashPath);
-        } else {
-          // If MagentaA11yV2 is not in the path, use the standard redirect
-          window.location.replace("/#" + currentPath);
-        }
-      }
+        pathSegmentsToKeep must be 0 because the site is served from the domain
+        root. Any other value silently breaks every deep link, and the symptom
+        is the homepage rather than an error.
+
+        The ~and~ substitution protects routes containing a literal &, for
+        example /how-to-test-criteria/test-type/keyboard-&-focus. Without it the
+        & is read as a query separator and the path is truncated.
+      */
+      var pathSegmentsToKeep = 0;
+
+      var l = window.location;
+      l.replace(
+        l.protocol + '//' + l.hostname + (l.port ? ':' + l.port : '') +
+        l.pathname.split('/').slice(0, 1 + pathSegmentsToKeep).join('/') + '/?/' +
+        l.pathname.slice(1).split('/').slice(pathSegmentsToKeep).join('/').replace(/&/g, '~and~') +
+        (l.search ? '&' + l.search.slice(1).replace(/&/g, '~and~') : '') +
+        l.hash
+      );
     </script>
   </head>
   <body>
-    <h1>Redirecting...</h1>
-    <p>
-      If you're not redirected automatically,
-      <a href="/MagentaA11yV2/#/">click here</a>.
-    </p>
+    <p>Redirecting to <a href="/">MagentaA11y</a>.</p>
   </body>
 </html>

--- a/public/content/documentation/how-to-test/test-type/not-sure-if-it-is-an-issue.md
+++ b/public/content/documentation/how-to-test/test-type/not-sure-if-it-is-an-issue.md
@@ -113,7 +113,7 @@ By combining both approaches, we can identify and address accessibility barriers
 
 6. ## Verify you are correctly using the screen reader or keyboard
 
-      Before you log an issue, make sure that you have tested it correctly. Refer to the MagentaAlly sections on How to test <a href="https://www.magentaa11y.com/#/how-to-test-criteria/test-type/keyboard-&-focus">Keyboard & focus</a> and <a href="https://www.magentaa11y.com/#/how-to-test-criteria/test-type/web-screen-readers">Screen readers</a> for guidance on system settings and methodology. 
+      Before you log an issue, make sure that you have tested it correctly. Refer to the MagentaAlly sections on How to test <a href="https://www.magentaa11y.com/how-to-test-criteria/test-type/keyboard-&-focus">Keyboard & focus</a> and <a href="https://www.magentaa11y.com/how-to-test-criteria/test-type/web-screen-readers">Screen readers</a> for guidance on system settings and methodology. 
 
       <div class="MagentaA11y-accordion">
       <h2 class="MagentaA11y-accordion__heading">

--- a/public/content/documentation/native/controls/button.md
+++ b/public/content/documentation/native/controls/button.md
@@ -31,7 +31,7 @@ How to test a button
 
     - Text resize: Text can resize up to 200% without losing information
 
-Full information: https://www.magentaa11y.com/#/native-criteria/controls/button
+Full information: https://www.magentaa11y.com/native-criteria/controls/button
 
 ## Gherkin
 ### #a11y - Native App Accessibility Acceptance Criteria
@@ -70,7 +70,7 @@ GIVEN THAT I am on a screen with a button
    - WHEN I adjust the device text resize setting to 200% 
       - THEN the text on the button should resize up to 200% without losing information 
 
-Full information: https://www.magentaa11y.com/#/native-criteria/controls/button
+Full information: https://www.magentaa11y.com/native-criteria/controls/button
 
 ## Videos
 

--- a/public/content/documentation/native/controls/calendar-date-picker.md
+++ b/public/content/documentation/native/controls/calendar-date-picker.md
@@ -30,7 +30,7 @@ How to test a calendar date picker
 
    - Text resize: Text can resize up to 200% without losing information
 
-Full information: [https://www.magentaa11y.com/#/native-criteria/controls/calendar-date-picker](/native-criteria/controls/calendar-date-picker)
+Full information: [https://www.magentaa11y.com/native-criteria/controls/calendar-date-picker](/native-criteria/controls/calendar-date-picker)
 
 ## Gherkin
 
@@ -70,7 +70,7 @@ GIVEN THAT I am on a screen with a calendar date picker
    - WHEN a user adjusts text resizing settings up to 200% 
       - THEN all text must remain readable without loss of information 
 
-Full information: [https://www.magentaa11y.com/#/native-criteria/controls/calendar-date-picker](/native-criteria/controls/calendar-date-picker)
+Full information: [https://www.magentaa11y.com/native-criteria/controls/calendar-date-picker](/native-criteria/controls/calendar-date-picker)
 
 ## iOS Developer Notes
 ### General Notes

--- a/public/content/documentation/native/controls/captcha.md
+++ b/public/content/documentation/native/controls/captcha.md
@@ -30,7 +30,7 @@ How to test a captcha
 
     - Text resize: n/a
 
-Full information: [https://www.magentaa11y.com/#/native-criteria/controls/captcha](/native-criteria/controls/captcha)
+Full information: [https://www.magentaa11y.com/native-criteria/controls/captcha](/native-criteria/controls/captcha)
 
 ## Gherkin
 
@@ -67,7 +67,7 @@ GIVEN THAT I am on a screen with a captcha
     - WHEN a user adjusts text resizing settings up to 200% 
         - THEN text resizing does not apply to the captcha functionality (n/a) 
 
-Full information: [https://www.magentaa11y.com/#/native-criteria/controls/captcha](/native-criteria/controls/captcha)
+Full information: [https://www.magentaa11y.com/native-criteria/controls/captcha](/native-criteria/controls/captcha)
 
 ## iOS Developer Notes
 

--- a/public/content/documentation/native/controls/carousel.md
+++ b/public/content/documentation/native/controls/carousel.md
@@ -46,7 +46,7 @@ How to test a carousel
       - Text resize: Text can resize up to 200% without losing information
 
 
-Full information: [https://www.magentaa11y.com/#/native-criteria/controls/carousel](/native-criteria/controls/carousel)
+Full information: [https://www.magentaa11y.com/native-criteria/controls/carousel](/native-criteria/controls/carousel)
 
 ## Gherkin
 
@@ -93,7 +93,7 @@ GIVEN THAT I am on a screen with a carousel
     - WHEN a user adjusts text resizing settings up to 200% 
         - THEN all text must remain readable without loss of information 
 
-Full information: [https://www.magentaa11y.com/#/native-criteria/controls/carousel](/native-criteria/controls/carousel)
+Full information: [https://www.magentaa11y.com/native-criteria/controls/carousel](/native-criteria/controls/carousel)
 
 ## iOS Developer Notes
 ### General Notes

--- a/public/content/documentation/native/controls/checkbox.md
+++ b/public/content/documentation/native/controls/checkbox.md
@@ -46,7 +46,7 @@ How to test a checkbox
 
    - Text resize: Text label can resize up to 200% without losing information
 
-Full information: [https://www.magentaa11y.com/#/native-criteria/controls/checkbox](/native-criteria/controls/checkbox)
+Full information: [https://www.magentaa11y.com/native-criteria/controls/checkbox](/native-criteria/controls/checkbox)
 
 ## Gherkin
 
@@ -86,7 +86,7 @@ GIVEN THAT I am on a screen with a checkbox
    - WHEN I adjust the device text resize setting to 200% 
       - THEN the text label should resize up to 200% without losing information 
 
-Full information: [https://www.magentaa11y.com/#/native-criteria/controls/checkbox](/native-criteria/controls/checkbox)
+Full information: [https://www.magentaa11y.com/native-criteria/controls/checkbox](/native-criteria/controls/checkbox)
 
 ## iOS Developer Notes
 ### General Notes

--- a/public/content/documentation/native/controls/chip.md
+++ b/public/content/documentation/native/controls/chip.md
@@ -38,7 +38,7 @@ How to test a chip
 
    - Text resize: Text can resize up to 200% without losing information
 
-Full information: [https://www.magentaa11y.com/#/native-criteria/controls/chip](/native-criteria/controls/chip)
+Full information: [https://www.magentaa11y.com/native-criteria/controls/chip](/native-criteria/controls/chip)
 
 ## Gherkin
 
@@ -77,7 +77,7 @@ GIVEN THAT I am on a screen with a chip
    - WHEN I adjust the device text resize setting to 200% 
       - THEN the text label should resize up to 200% without losing information 
 
-Full information: [https://www.magentaa11y.com/#/native-criteria/controls/chip](/native-criteria/controls/chip)
+Full information: [https://www.magentaa11y.com/native-criteria/controls/chip](/native-criteria/controls/chip)
 
 ## iOS Developer Notes
 There is no native chip element for iOS.  The notes below are suggestions and accessibility guidance.

--- a/public/content/documentation/native/controls/date-time-picker.md
+++ b/public/content/documentation/native/controls/date-time-picker.md
@@ -31,7 +31,7 @@ How to test a date time picker
 
    - Text resize: Text can resize up to 200% without losing information
 
-Full information: [https://www.magentaa11y.com/#/native-criteria/inputs/date-time-picker](/native-criteria/inputs/date-time-picker)
+Full information: [https://www.magentaa11y.com/native-criteria/inputs/date-time-picker](/native-criteria/inputs/date-time-picker)
 
 ## Gherkin
 
@@ -74,7 +74,7 @@ GIVEN THAT I am on a screen with a date time picker
    - WHEN the user adjusts text resizing settings up to 200% 
       - THEN all text must remain readable without loss of information 
 
-Full information: [https://www.magentaa11y.com/#/native-criteria/inputs/date-time-picker](/native-criteria/inputs/date-time-picker)
+Full information: [https://www.magentaa11y.com/native-criteria/inputs/date-time-picker](/native-criteria/inputs/date-time-picker)
 
 ## iOS Developer Notes
 ### General Notes

--- a/public/content/documentation/native/controls/dropdown.md
+++ b/public/content/documentation/native/controls/dropdown.md
@@ -46,7 +46,7 @@ How to test a dropdown
 
    - Text resize: Text can resize up to 200% without losing information
 
-Full information: [https://www.magentaa11y.com/#/native-criteria/controls/dropdown](/native-criteria/controls/dropdown)
+Full information: [https://www.magentaa11y.com/native-criteria/controls/dropdown](/native-criteria/controls/dropdown)
 
 ## Gherkin
 
@@ -89,7 +89,7 @@ GIVEN THAT I am on a screen with a dropdown
    - WHEN I adjust the device text resize setting to 200%
       - THEN the text on the dropdown should resize up to 200% without losing information
 
-Full information: [https://www.magentaa11y.com/#/native-criteria/controls/dropdown](/native-criteria/controls/dropdown)
+Full information: [https://www.magentaa11y.com/native-criteria/controls/dropdown](/native-criteria/controls/dropdown)
 
 ## iOS Developer Notes
 There is no native dropdown element for iOS.  The notes below are suggestions and accessibility guidance.

--- a/public/content/documentation/native/controls/expandable.md
+++ b/public/content/documentation/native/controls/expandable.md
@@ -49,7 +49,7 @@ How to test a button that toggles an expandable region
 
    - Text resize: Text can resize up to 200% without losing information
 
-Full information: [https://www.magentaa11y.com/#/native-criteria/controls/expandable](/native-criteria/controls/expandable)
+Full information: [https://www.magentaa11y.com/native-criteria/controls/expandable](/native-criteria/controls/expandable)
 
 ## Gherkin
 
@@ -87,7 +87,7 @@ GIVEN THAT I am on a screen with an expandable region
    - WHEN I adjust the device text resize setting to 200%
       - THEN the text on the expandable region should resize up to 200% without losing information
 
-Full information: [https://www.magentaa11y.com/#/native-criteria/controls/expandable](/native-criteria/controls/expandable)
+Full information: [https://www.magentaa11y.com/native-criteria/controls/expandable](/native-criteria/controls/expandable)
 
 
 ## iOS Developer Notes

--- a/public/content/documentation/native/controls/link.md
+++ b/public/content/documentation/native/controls/link.md
@@ -31,7 +31,7 @@ How to test a link
 
    - Text resize: Text can resize up to 200% without losing information
 
-Full information: [https://www.magentaa11y.com/#/native-criteria/controls/link](/native-criteria/controls/link)
+Full information: [https://www.magentaa11y.com/native-criteria/controls/link](/native-criteria/controls/link)
 
 ## Gherkin
 
@@ -74,7 +74,7 @@ GIVEN THAT I am on a screen with a link
    - WHEN I adjust the device text resize setting to 200% 
       - THEN the text of the link should resize up to 200% without losing information 
 
-Full information: [https://www.magentaa11y.com/#/native-criteria/controls/link](/native-criteria/controls/link)
+Full information: [https://www.magentaa11y.com/native-criteria/controls/link](/native-criteria/controls/link)
 
 ## Videos
 

--- a/public/content/documentation/native/controls/menu.md
+++ b/public/content/documentation/native/controls/menu.md
@@ -49,7 +49,7 @@ How to test a menu
 
    - Text resize: Text can resize up to 200% without losing information
 
-Full information: [https://www.magentaa11y.com/#/native-criteria/controls/menu](/native-criteria/controls/menu)
+Full information: [https://www.magentaa11y.com/native-criteria/controls/menu](/native-criteria/controls/menu)
 
 ## Gherkin
 
@@ -92,7 +92,7 @@ GIVEN THAT I am on a screen with a menu
    - WHEN I adjust the device text resize setting to 200%
       - THEN the text within the menu should resize up to 200% without losing information 
 
-Full information: [https://www.magentaa11y.com/#/native-criteria/controls/menu](/native-criteria/controls/menu)
+Full information: [https://www.magentaa11y.com/native-criteria/controls/menu](/native-criteria/controls/menu)
 
 ## iOS Developer Notes
 ### General Notes

--- a/public/content/documentation/native/controls/pagination-control.md
+++ b/public/content/documentation/native/controls/pagination-control.md
@@ -49,7 +49,7 @@ How to test a pagination control
 
    - Text resize: n/a
 
-Full information: [https://www.magentaa11y.com/#/native-criteria/controls/pagination-control](/native-criteria/controls/pagination-control)
+Full information: [https://www.magentaa11y.com/native-criteria/controls/pagination-control](/native-criteria/controls/pagination-control)
 
 ## Gherkin
 
@@ -90,7 +90,7 @@ GIVEN THAT I am on a screen with a pagination control
    - WHEN I have increased text size in device settings 
       - THEN text resize interaction is N/A 
 
-Full information: [https://www.magentaa11y.com/#/native-criteria/controls/pagination-control](/native-criteria/controls/pagination-control)
+Full information: [https://www.magentaa11y.com/native-criteria/controls/pagination-control](/native-criteria/controls/pagination-control)
 
 ## iOS Developer Notes
 ### General Notes

--- a/public/content/documentation/native/controls/progress-indicator.md
+++ b/public/content/documentation/native/controls/progress-indicator.md
@@ -46,7 +46,7 @@ How to test a progress indicator
 
    - Text resize: Text can resize up to 200% without losing information
 
-Full information: [https://www.magentaa11y.com/#/native-criteria/controls/progress-indicator](/native-criteria/controls/progress-indicator)
+Full information: [https://www.magentaa11y.com/native-criteria/controls/progress-indicator](/native-criteria/controls/progress-indicator)
 
 ## Gherkin
 
@@ -84,7 +84,7 @@ GIVEN THAT I am on a screen with a progress indicator
    - WHEN I adjust the device text resize setting to 200% 
       - THEN the text should resize up to 200% without losing information 
 
-Full information: [https://www.magentaa11y.com/#/native-criteria/controls/progress-indicator](/native-criteria/controls/progress-indicator)
+Full information: [https://www.magentaa11y.com/native-criteria/controls/progress-indicator](/native-criteria/controls/progress-indicator)
 
 ## iOS Developer Notes
 ### General Notes

--- a/public/content/documentation/native/controls/radio-button.md
+++ b/public/content/documentation/native/controls/radio-button.md
@@ -30,7 +30,7 @@ How to test a radio button
 
    - Text resize: Text label can resize up to 200% without losing information
 
-Full information: [https://www.magentaa11y.com/#/native-criteria/controls/radio-button](/native-criteria/controls/radio-button)
+Full information: [https://www.magentaa11y.com/native-criteria/controls/radio-button](/native-criteria/controls/radio-button)
 
 ## Gherkin
 
@@ -70,7 +70,7 @@ GIVEN THAT I am on a screen with a radio button
    - WHEN I adjust the device text resize setting to 200% 
       - THEN the text label should resize up to 200% without losing information 
 
-Full information: [https://www.magentaa11y.com/#/native-criteria/controls/radio-button](/native-criteria/controls/radio-button)
+Full information: [https://www.magentaa11y.com/native-criteria/controls/radio-button](/native-criteria/controls/radio-button)
 
 ## Videos
 

--- a/public/content/documentation/native/controls/reorder-data-row.md
+++ b/public/content/documentation/native/controls/reorder-data-row.md
@@ -46,7 +46,7 @@ How to test a reorder data row
 
    - Text resize: Text can resize up to 200% without losing information (visible label text)
 
-Full information: [https://www.magentaa11y.com/#/native-criteria/controls/reorder-data-row](/native-criteria/controls/reorder-data-row)
+Full information: [https://www.magentaa11y.com/native-criteria/controls/reorder-data-row](/native-criteria/controls/reorder-data-row)
 
 ## Gherkin
 
@@ -83,7 +83,7 @@ GIVEN THAT I am on a screen with a reorder data row
    - WHEN I adjust the device text resize setting to 200% 
       - THEN the text should resize up to 200% without losing information (visible label text)
 
-Full information: [https://www.magentaa11y.com/#/native-criteria/controls/reorder-data-row](/native-criteria/controls/reorder-data-row)
+Full information: [https://www.magentaa11y.com/native-criteria/controls/reorder-data-row](/native-criteria/controls/reorder-data-row)
 
 ## iOS Developer Notes
 ### General Notes

--- a/public/content/documentation/native/controls/search.md
+++ b/public/content/documentation/native/controls/search.md
@@ -47,7 +47,7 @@ How to test a search
 
    - Text resize: Text can resize up to 200% without losing information
 
-Full information: [https://www.magentaa11y.com/#/native-criteria/controls/search](/native-criteria/controls/search)
+Full information: [https://www.magentaa11y.com/native-criteria/controls/search](/native-criteria/controls/search)
 
 ## Gherkin
 
@@ -86,7 +86,7 @@ GIVEN THAT I am on a screen with a search
    - WHEN I adjust the device text resize setting to 200% 
       - THEN the text within the search field should resize up to 200% without losing information 
 
-Full information: [https://www.magentaa11y.com/#/native-criteria/controls/search](/native-criteria/controls/search)
+Full information: [https://www.magentaa11y.com/native-criteria/controls/search](/native-criteria/controls/search)
 
 ## iOS Developer Notes
 ### General Notes

--- a/public/content/documentation/native/controls/segmented-control.md
+++ b/public/content/documentation/native/controls/segmented-control.md
@@ -49,7 +49,7 @@ How to test a segemented control / tabs
 
    - Text resize: This element is exempt from text resizing requirements
 
-Full information: [https://www.magentaa11y.com/#/native-criteria/controls/segmented-control](/native-criteria/controls/segmented-control)
+Full information: [https://www.magentaa11y.com/native-criteria/controls/segmented-control](/native-criteria/controls/segmented-control)
 
 ## Gherkin
 
@@ -91,7 +91,7 @@ GIVEN THAT I am on a screen with a segemented control / tabs
    - WHEN I adjust the device text resize setting 
       - THEN this element remains exempt from text resizing requirements 
 
-Full information: [https://www.magentaa11y.com/#/native-criteria/controls/segmented-control](/native-criteria/controls/segmented-control)
+Full information: [https://www.magentaa11y.com/native-criteria/controls/segmented-control](/native-criteria/controls/segmented-control)
 
 ## iOS Developer Notes
 ### General Notes

--- a/public/content/documentation/native/controls/sheet.md
+++ b/public/content/documentation/native/controls/sheet.md
@@ -31,7 +31,7 @@ Enter will also activate any other interactive element in the sheet.
 
    - Text resize: Text can resize up to 200% without losing information
 
-Full information: [https://www.magentaa11y.com/#/native-criteria/controls/sheet](/native-criteria/controls/sheet)
+Full information: [https://www.magentaa11y.com/native-criteria/controls/sheet](/native-criteria/controls/sheet)
 
 ## Gherkin
 
@@ -78,7 +78,7 @@ GIVEN THAT I am on a screen with a sheet
    - WHEN I adjust the device text resize setting to 200%
       - THEN all text must remain readable without loss of information 
 
-Full information: [https://www.magentaa11y.com/#/native-criteria/controls/sheet](/native-criteria/controls/sheet)
+Full information: [https://www.magentaa11y.com/native-criteria/controls/sheet](/native-criteria/controls/sheet)
 
 ## iOS Developer Notes
 ### General Notes

--- a/public/content/documentation/native/controls/sidebar-menu.md
+++ b/public/content/documentation/native/controls/sidebar-menu.md
@@ -52,7 +52,7 @@ How to test a sidebar navigation menu
 
    - Text resize: Text can resize up to 200% without losing information
 
-Full information: [https://www.magentaa11y.com/#/native-criteria/controls/sidebar-menu](/native-criteria/controls/sidebar-menu)
+Full information: [https://www.magentaa11y.com/native-criteria/controls/sidebar-menu](/native-criteria/controls/sidebar-menu)
 
 ## Gherkin
 
@@ -100,7 +100,7 @@ GIVEN THAT I am on a screen with a sidebar navigation menu
    - WHEN I adjust the device text resize setting to 200%
       - THEN the text should resize up to 200% without losing information 
 
-Full information: [https://www.magentaa11y.com/#/native-criteria/controls/sidebar-menu](/native-criteria/controls/sidebar-menu)
+Full information: [https://www.magentaa11y.com/native-criteria/controls/sidebar-menu](/native-criteria/controls/sidebar-menu)
 
 ## iOS Developer Notes
 ### General Notes

--- a/public/content/documentation/native/controls/slider.md
+++ b/public/content/documentation/native/controls/slider.md
@@ -48,7 +48,7 @@ How to test a slider
 
    - Text resize: Text can resize up to 200% without losing information
 
-Full information: [https://www.magentaa11y.com/#/native-criteria/controls/slider](/native-criteria/controls/slider)
+Full information: [https://www.magentaa11y.com/native-criteria/controls/slider](/native-criteria/controls/slider)
 
 ## Gherkin
 
@@ -90,7 +90,7 @@ GIVEN THAT I am on a screen with a slider
    - WHEN I adjust the device text resize setting to 200%
       - THEN the text label should resize up to 200% without losing information 
 
-Full information: [https://www.magentaa11y.com/#/native-criteria/controls/slider](/native-criteria/controls/slider)
+Full information: [https://www.magentaa11y.com/native-criteria/controls/slider](/native-criteria/controls/slider)
 
 ## iOS Developer Notes
 ### General Notes

--- a/public/content/documentation/native/controls/step-indicator.md
+++ b/public/content/documentation/native/controls/step-indicator.md
@@ -28,7 +28,7 @@ How to test a step indicator
 
     - Text resize: Text can resize up to 200% without losing information
 
-Full information: [https://www.magentaa11y.com/#/native-criteria/controls/step-indicator](/native-criteria/controls/step-indicator)
+Full information: [https://www.magentaa11y.com/native-criteria/controls/step-indicator](/native-criteria/controls/step-indicator)
 
 ## Gherkin
 
@@ -66,7 +66,7 @@ GIVEN THAT I am on a screen with a step indicator
    - WHEN I adjust the device text resize setting to 200%
       - THEN the text should resize up to 200% without losing information 
 
-Full information: [https://www.magentaa11y.com/#/native-criteria/controls/step-indicator](/native-criteria/controls/step-indicator)
+Full information: [https://www.magentaa11y.com/native-criteria/controls/step-indicator](/native-criteria/controls/step-indicator)
 
 ## iOS Developer Notes
 ### General Notes

--- a/public/content/documentation/native/controls/stepper.md
+++ b/public/content/documentation/native/controls/stepper.md
@@ -48,7 +48,7 @@ How to test a stepper
 
    - Text resize: Text can resize up to 200% without losing information
 
-Full information: [https://www.magentaa11y.com/#/native-criteria/controls/stepper](/native-criteria/controls/stepper)
+Full information: [https://www.magentaa11y.com/native-criteria/controls/stepper](/native-criteria/controls/stepper)
 
 ## Gherkin
 
@@ -89,7 +89,7 @@ GIVEN THAT I am on a screen with a stepper
    - WHEN the text resize setting is increased up to 200% 
       - THEN the text within the stepper should remain readable without losing information or functionality 
 
-Full information: [https://www.magentaa11y.com/#/native-criteria/controls/stepper](/native-criteria/controls/stepper)
+Full information: [https://www.magentaa11y.com/native-criteria/controls/stepper](/native-criteria/controls/stepper)
 
 ## iOS Developer Notes
 ### General Notes

--- a/public/content/documentation/native/controls/table-row-button.md
+++ b/public/content/documentation/native/controls/table-row-button.md
@@ -48,7 +48,7 @@ How to test a table row button / list item
 
    - Text resize: Text can resize up to 200% without losing information
 
-Full information: [https://www.magentaa11y.com/#/native-criteria/controls/table-row-button](/native-criteria/controls/table-row-button)
+Full information: [https://www.magentaa11y.com/native-criteria/controls/table-row-button](/native-criteria/controls/table-row-button)
 
 ## Gherkin
 
@@ -89,7 +89,7 @@ GIVEN THAT I am on a screen with a table row button / list item
    - WHEN the text resize setting is increased up to 200% 
       - THEN the text within the row or blade should remain readable without losing information or functionality 
 
-Full information: [https://www.magentaa11y.com/#/native-criteria/controls/table-row-button](/native-criteria/controls/table-row-button)
+Full information: [https://www.magentaa11y.com/native-criteria/controls/table-row-button](/native-criteria/controls/table-row-button)
 
 ## iOS Developer Notes
 ### General Notes

--- a/public/content/documentation/native/controls/text-input.md
+++ b/public/content/documentation/native/controls/text-input.md
@@ -47,7 +47,7 @@ How to test a text input
 
    - Text resize: Text can resize up to 200% without losing information
 
-Full information: [https://www.magentaa11y.com/#/native-criteria/controls/text-input](/native-criteria/controls/text-input)
+Full information: [https://www.magentaa11y.com/native-criteria/controls/text-input](/native-criteria/controls/text-input)
 
 ## Gherkin
 
@@ -85,7 +85,7 @@ GIVEN THAT I am on a screen with a text input
    - WHEN I adjust the device text resize setting to 200%
       - THEN the text within the text input should resize up to 200% without losing information 
 
-Full information: [https://www.magentaa11y.com/#/native-criteria/controls/text-input](/native-criteria/controls/text-input)
+Full information: [https://www.magentaa11y.com/native-criteria/controls/text-input](/native-criteria/controls/text-input)
 
 ## iOS Developer Notes
 ### General Notes

--- a/public/content/documentation/native/controls/time-picker.md
+++ b/public/content/documentation/native/controls/time-picker.md
@@ -48,7 +48,7 @@ How to test a time picker
 
    - Text resize: Text can resize up to 200% without losing information
 
-Full information: [https://www.magentaa11y.com/#/native-criteria/controls/time-picker](/native-criteria/controls/time-picker)
+Full information: [https://www.magentaa11y.com/native-criteria/controls/time-picker](/native-criteria/controls/time-picker)
 
 ## Gherkin
 
@@ -89,7 +89,7 @@ GIVEN THAT I am on a screen with a time picker
    - WHEN the text resize setting is increased up to 200% 
       - THEN the text within the time picker should remain readable without losing information or functionality 
 
-Full information: [https://www.magentaa11y.com/#/native-criteria/controls/time-picker](/native-criteria/controls/time-picker)
+Full information: [https://www.magentaa11y.com/native-criteria/controls/time-picker](/native-criteria/controls/time-picker)
 
 ## iOS Developer Notes
 ### General Notes

--- a/public/content/documentation/native/controls/timer.md
+++ b/public/content/documentation/native/controls/timer.md
@@ -28,7 +28,7 @@ How to test a timer
 
    - Text resize: Text can resize up to 200% without losing information
 
-Full information: [https://www.magentaa11y.com/#/native-criteria/controls/timer](/native-criteria/controls/timer)
+Full information: [https://www.magentaa11y.com/native-criteria/controls/timer](/native-criteria/controls/timer)
 
 ## Gherkin
 
@@ -66,7 +66,7 @@ GIVEN THAT I am on a screen with a timer
    - WHEN a user adjusts text resizing settings up to 200% 
       - THEN all text must remain readable without loss of information
 
-Full information: [https://www.magentaa11y.com/#/native-criteria/controls/timer](/native-criteria/controls/timer)
+Full information: [https://www.magentaa11y.com/native-criteria/controls/timer](/native-criteria/controls/timer)
 
 ## iOS Developer Notes
 ### General Notes

--- a/public/content/documentation/native/controls/toggle-switch.md
+++ b/public/content/documentation/native/controls/toggle-switch.md
@@ -48,7 +48,7 @@ How to test a toggle switch
 
    - Text resize: Text can resize up to 200% without losing information
 
-Full information: [https://www.magentaa11y.com/#/native-criteria/controls/toggle-switch](/native-criteria/controls/toggle-switch)
+Full information: [https://www.magentaa11y.com/native-criteria/controls/toggle-switch](/native-criteria/controls/toggle-switch)
 
 ## Gherkin
 
@@ -89,7 +89,7 @@ GIVEN THAT I am on a screen with a toggle switch
    - WHEN the text resize setting is increased up to 200% 
       - THEN the text within the toggle switch or table row with a toggle switch should remain readable without losing information or functionality 
 
-Full information: [https://www.magentaa11y.com/#/native-criteria/controls/toggle-switch](/native-criteria/controls/toggle-switch)
+Full information: [https://www.magentaa11y.com/native-criteria/controls/toggle-switch](/native-criteria/controls/toggle-switch)
 
 ## iOS Developer Notes
 ### General Notes

--- a/public/content/documentation/native/notifications/alert-dialog.md
+++ b/public/content/documentation/native/notifications/alert-dialog.md
@@ -49,7 +49,7 @@ How to test an alert dialog
 
    - Text resize: Text can resize up to 200% without losing information
 
-Full information: [https://www.magentaa11y.com/#/native-criteria/notifications/alert-dialog](/native-criteria/notifications/alert-dialog)
+Full information: [https://www.magentaa11y.com/native-criteria/notifications/alert-dialog](/native-criteria/notifications/alert-dialog)
 
 ## Gherkin
 
@@ -91,7 +91,7 @@ GIVEN THAT I am on a screen with an alert dialog
    - WHEN the text resize setting is increased up to 200% 
       - THEN the text within the alert should remain readable without losing information or functionality 
 
-Full information: [https://www.magentaa11y.com/#/native-criteria/notifications/alert-dialog](/native-criteria/notifications/alert-dialog)
+Full information: [https://www.magentaa11y.com/native-criteria/notifications/alert-dialog](/native-criteria/notifications/alert-dialog)
 
 ## iOS Developer Notes
 ### General Notes

--- a/public/content/documentation/native/notifications/modal.md
+++ b/public/content/documentation/native/notifications/modal.md
@@ -49,7 +49,7 @@ How to test a modal
 
    - Text resize: Text can resize up to 200% without losing information
 
-Full information: [https://www.magentaa11y.com/#/native-criteria/controls/segmented-control](/native-criteria/controls/segmented-control)
+Full information: [https://www.magentaa11y.com/native-criteria/controls/segmented-control](/native-criteria/controls/segmented-control)
 
 ## Gherkin
 
@@ -90,7 +90,7 @@ GIVEN THAT I am on a screen with a modal
    - WHEN I have increased text size in device settings
         - THEN text should resize up to 200% without losing information 
 
-Full information: [https://www.magentaa11y.com/#/native-criteria/controls/segmented-control](/native-criteria/controls/segmented-control)
+Full information: [https://www.magentaa11y.com/native-criteria/controls/segmented-control](/native-criteria/controls/segmented-control)
 
 ## iOS Developer Notes
 ### General Notes

--- a/public/content/documentation/native/notifications/snackbar-toast.md
+++ b/public/content/documentation/native/notifications/snackbar-toast.md
@@ -32,7 +32,7 @@ How to test a snackbar/toast
 
    - Text resize: Text can resize up to 200% without losing information
 
-Full information: [https://www.magentaa11y.com/#/native-criteria/notifications/snackbar-toast](/native-criteria/notifications/snackbar-toast)
+Full information: [https://www.magentaa11y.com/native-criteria/notifications/snackbar-toast](/native-criteria/notifications/snackbar-toast)
 
 ## Gherkin
 
@@ -77,7 +77,7 @@ GIVEN THAT I am on a screen with a snackbar/toast
       - THEN all text within the snackbar should remain fully readable
          - AND no content or functionality should be lost or cut off 
 
-Full information: [https://www.magentaa11y.com/#/native-criteria/notifications/snackbar-toast](/native-criteria/notifications/snackbar-toast)
+Full information: [https://www.magentaa11y.com/native-criteria/notifications/snackbar-toast](/native-criteria/notifications/snackbar-toast)
 
 ## iOS Developer Notes
 

--- a/public/content/documentation/native/patterns/animation.md
+++ b/public/content/documentation/native/patterns/animation.md
@@ -42,7 +42,7 @@ How to test an animation
 
    - Text resize: N/A
 
-Full information: [https://www.magentaa11y.com/#/native-criteria/patterns/animation](/native-criteria/patterns/animation)
+Full information: [https://www.magentaa11y.com/native-criteria/patterns/animation](/native-criteria/patterns/animation)
 
 ## Gherkin
 
@@ -73,7 +73,7 @@ GIVEN THAT I am on a screen with an animation
    - WHEN I have increased text size in device settings
       - THEN text resize interaction is N/A 
  
-Full information: [https://www.magentaa11y.com/#/native-criteria/patterns/animation](/native-criteria/patterns/animation)
+Full information: [https://www.magentaa11y.com/native-criteria/patterns/animation](/native-criteria/patterns/animation)
 
 ## iOS Developer Notes
 ### General Notes

--- a/public/content/documentation/native/patterns/field-errors.md
+++ b/public/content/documentation/native/patterns/field-errors.md
@@ -33,7 +33,7 @@ How to test a field error
 
    - Text resize: Text can resize up to 200% without losing information
 
-Full information: [https://www.magentaa11y.com/#/native-criteria/patterns/field-errors](/native-criteria/patterns/field-errors)
+Full information: [https://www.magentaa11y.com/native-criteria/patterns/field-errors](/native-criteria/patterns/field-errors)
 
 ## Gherkin
 
@@ -66,7 +66,7 @@ GIVEN THAT I am on a screen with a field error
    - WHEN I have increased text size up to 200% in the device settings   
       - THEN the text should resize without losing information   
 
-Full information: [https://www.magentaa11y.com/#/native-criteria/patterns/field-errors](/native-criteria/patterns/field-errors)
+Full information: [https://www.magentaa11y.com/native-criteria/patterns/field-errors](/native-criteria/patterns/field-errors)
 
 ## iOS Developer Notes
 ### General Notes

--- a/public/content/documentation/native/patterns/focus.md
+++ b/public/content/documentation/native/patterns/focus.md
@@ -24,7 +24,7 @@ How to test focus
    - Navigate: Focus moves left to right, top to bottom in a logical order
    - Visible focus indicator: Is clearly shown around content when tapped or with navigation gestures
 
-Full information: [https://www.magentaa11y.com/#/native-criteria/patterns/focus](/native-criteria/patterns/focus)
+Full information: [https://www.magentaa11y.com/native-criteria/patterns/focus](/native-criteria/patterns/focus)
 
 ## Gherkin
 
@@ -62,7 +62,7 @@ GIVEN THAT I am on a screen with focus
       - THEN the focus should visibly move to all controls without losing information 
          - AND a visible focus indicator should be clearly shown around controls in a logical order without losing information 
 
-Full information: [https://www.magentaa11y.com/#/native-criteria/patterns/focus](/native-criteria/patterns/focus)
+Full information: [https://www.magentaa11y.com/native-criteria/patterns/focus](/native-criteria/patterns/focus)
 
 ## iOS Developer Notes
 ### General Notes

--- a/public/content/documentation/native/patterns/graphics-visual-elements.md
+++ b/public/content/documentation/native/patterns/graphics-visual-elements.md
@@ -48,7 +48,7 @@ How to test a graphic/visual element
 
    - Text resize: Text can resize up to 200% without losing information. Text in images do not resize
 
-Full information: [https://www.magentaa11y.com/#/native-criteria/patterns/graphics-visual-elements](/native-criteria/patterns/graphics-visual-elements)
+Full information: [https://www.magentaa11y.com/native-criteria/patterns/graphics-visual-elements](/native-criteria/patterns/graphics-visual-elements)
 
 ## Gherkin
 
@@ -91,7 +91,7 @@ GIVEN THAT I am on a screen with a graphic/visual element
       - THEN text should resize up to 200% without losing information
          - AND text within images should not resize
 
-Full information: [https://www.magentaa11y.com/#/native-criteria/patterns/graphics-visual-elements](/native-criteria/patterns/graphics-visual-elements)
+Full information: [https://www.magentaa11y.com/native-criteria/patterns/graphics-visual-elements](/native-criteria/patterns/graphics-visual-elements)
 
 ## iOS Developer Notes
 ### General Notes

--- a/public/content/documentation/native/patterns/headings.md
+++ b/public/content/documentation/native/patterns/headings.md
@@ -42,7 +42,7 @@ How to test a heading
 
    - Text resize: Text can resize up to 200% without losing information
 
-Full information: [https://www.magentaa11y.com/#/native-criteria/patterns/headings](/native-criteria/patterns/headings)
+Full information: [https://www.magentaa11y.com/native-criteria/patterns/headings](/native-criteria/patterns/headings)
 
 ## Gherkin
 
@@ -75,7 +75,7 @@ GIVEN THAT I am on a screen with a heading
    - WHEN text resizing settings are adjusted on the device 
       - THEN all previously noted functionality must be focusable and announced 
 
-Full information: [https://www.magentaa11y.com/#/native-criteria/patterns/headings](/native-criteria/patterns/headings)
+Full information: [https://www.magentaa11y.com/native-criteria/patterns/headings](/native-criteria/patterns/headings)
 
 ## iOS Developer Notes
 ### General Notes

--- a/public/content/documentation/native/patterns/image-decorative.md
+++ b/public/content/documentation/native/patterns/image-decorative.md
@@ -24,7 +24,7 @@ How to test a decorative image or icon
 
    - Text resize: N/A
 
-Full information: [https://www.magentaa11y.com/#/native-criteria/patterns/image-decorative](/native-criteria/patterns/image-decorative)
+Full information: [https://www.magentaa11y.com/native-criteria/patterns/image-decorative](/native-criteria/patterns/image-decorative)
 
 ## Gherkin
 
@@ -57,7 +57,7 @@ GIVEN THAT I am on a screen with a decorative image or icon
       - AND I swipe to browse to an image or icon
          - I HEAR the image or icon is ignored, N/A
 
-Full information: [https://www.magentaa11y.com/#/native-criteria/patterns/image-decorative](/native-criteria/patterns/image-decorative)
+Full information: [https://www.magentaa11y.com/native-criteria/patterns/image-decorative](/native-criteria/patterns/image-decorative)
 
 ## iOS Developer Notes
 ### General Notes

--- a/public/content/documentation/native/patterns/loading-icon.md
+++ b/public/content/documentation/native/patterns/loading-icon.md
@@ -34,7 +34,7 @@ How to test a loading icon
 
    - Text resize: N/A
 
-Full information: [https://www.magentaa11y.com/#/native-criteria/patterns/loading-icon](/native-criteria/patterns/loading-icon)
+Full information: [https://www.magentaa11y.com/native-criteria/patterns/loading-icon](/native-criteria/patterns/loading-icon)
 
 ## Gherkin
 
@@ -65,7 +65,7 @@ GIVEN THAT I am on a screen with a loading icon
    - WHEN I have increased text size in device settings
       - THEN text resize interaction is N/A 
 
-Full information: [https://www.magentaa11y.com/#/native-criteria/patterns/loading-icon](/native-criteria/patterns/loading-icon)
+Full information: [https://www.magentaa11y.com/native-criteria/patterns/loading-icon](/native-criteria/patterns/loading-icon)
 
 ## iOS Developer Notes
 ### General Notes

--- a/public/content/documentation/native/patterns/loading-spinner.md
+++ b/public/content/documentation/native/patterns/loading-spinner.md
@@ -24,7 +24,7 @@ How to test a loading spinner
 
    - Text resize: N/A
 
-Full information: [https://www.magentaa11y.com/#/native-criteria/patterns/loading-spinner](/native-criteria/patterns/loading-spinner)
+Full information: [https://www.magentaa11y.com/native-criteria/patterns/loading-spinner](/native-criteria/patterns/loading-spinner)
 
 ## Gherkin
 
@@ -55,7 +55,7 @@ GIVEN THAT I am on a screen with a loading spinner
    - WHEN I have increased text size in device settings
       - THEN text resize interaction is N/A 
 
-Full information: [https://www.magentaa11y.com/#/native-criteria/patterns/loading-spinner](/native-criteria/patterns/loading-spinner)
+Full information: [https://www.magentaa11y.com/native-criteria/patterns/loading-spinner](/native-criteria/patterns/loading-spinner)
 
 ## iOS Developer Notes
 ### General Notes

--- a/public/content/documentation/native/patterns/strike-through.md
+++ b/public/content/documentation/native/patterns/strike-through.md
@@ -25,7 +25,7 @@ How to test strike-through text
 
    - Text resize: Text can resize up to 200% without losing information
 
-Full information: [https://www.magentaa11y.com/#/native-criteria/patterns/strike-through](/native-criteria/patterns/strike-through)
+Full information: [https://www.magentaa11y.com/native-criteria/patterns/strike-through](/native-criteria/patterns/strike-through)
 
 ## Gherkin
 
@@ -56,7 +56,7 @@ GIVEN THAT I am on a screen with a strike-through text
    - WHEN I have increased text size in device settings 
       - THEN text should resize up to 200% without losing information 
 
-Full information: [https://www.magentaa11y.com/#/native-criteria/patterns/strike-through](/native-criteria/patterns/strike-through)
+Full information: [https://www.magentaa11y.com/native-criteria/patterns/strike-through](/native-criteria/patterns/strike-through)
 
 ## iOS Developer Notes
 ### General Notes

--- a/public/content/documentation/native/patterns/table.md
+++ b/public/content/documentation/native/patterns/table.md
@@ -40,7 +40,7 @@ How to test a table
 
    - Text resize: Text can resize up to 200% without losing information
 
-Full information: [https://www.magentaa11y.com/#/native-criteria/patterns/table](/native-criteria/patterns/table)
+Full information: [https://www.magentaa11y.com/native-criteria/patterns/table](/native-criteria/patterns/table)
 
 ## Gherkin
 
@@ -77,7 +77,7 @@ GIVEN THAT I am on a screen with a table
    - WHEN I have increased text size up to 200% in the device settings 
       - THEN all text should resize without losing information
 
-Full information: [https://www.magentaa11y.com/#/native-criteria/patterns/table](/native-criteria/patterns/table)
+Full information: [https://www.magentaa11y.com/native-criteria/patterns/table](/native-criteria/patterns/table)
 
 ## iOS Developer Notes
 ### General Notes

--- a/public/content/documentation/native/patterns/tidbit.md
+++ b/public/content/documentation/native/patterns/tidbit.md
@@ -30,7 +30,7 @@ How to test a tidbit
 
    - Text resize: Text can resize up to 200% without losing information
 
-Full information: [https://www.magentaa11y.com/#/native-criteria/patterns/tidbit](/native-criteria/patterns/tidbit)
+Full information: [https://www.magentaa11y.com/native-criteria/patterns/tidbit](/native-criteria/patterns/tidbit)
 
 ## Gherkin
 
@@ -71,7 +71,7 @@ GIVEN THAT I am on a screen with a tidbit
    - WHEN I have increased text size up to 200% in the device settings
         - THEN text should resize up to 200% without losing information 
 
-Full information: [https://www.magentaa11y.com/#/native-criteria/patterns/tidbit](/native-criteria/patterns/tidbit)
+Full information: [https://www.magentaa11y.com/native-criteria/patterns/tidbit](/native-criteria/patterns/tidbit)
 
 ## Videos
 
@@ -116,7 +116,7 @@ Full information: [https://www.magentaa11y.com/#/native-criteria/patterns/tidbit
 
 ### Role
 
-   - Please use guidance for the <a href="https://www.magentaa11y.com/#/native-criteria/controls/button">Button control</a> if a CTA is applicable
+   - Please use guidance for the <a href="https://www.magentaa11y.com/native-criteria/controls/button">Button control</a> if a CTA is applicable
 
 ### Groupings
 
@@ -203,7 +203,7 @@ Enter information for iOS Focus using SwiftUI, update below with appropriate det
 
 ### Role
 
-   - Please use guidance for the <a href="https://www.magentaa11y.com/#/native-criteria/controls/button">Button control</a> if a CTA is applicable
+   - Please use guidance for the <a href="https://www.magentaa11y.com/native-criteria/controls/button">Button control</a> if a CTA is applicable
 
 ### Groupings
 

--- a/public/content/documentation/native/patterns/webview.md
+++ b/public/content/documentation/native/patterns/webview.md
@@ -46,7 +46,7 @@ How to test a webview
 
    - Text resize: N/A only for webview sections and native navigation bar text
 
-Full information: [https://www.magentaa11y.com/#/native-criteria/patterns/webview](/native-criteria/patterns/webview)
+Full information: [https://www.magentaa11y.com/native-criteria/patterns/webview](/native-criteria/patterns/webview)
 
 ## Gherkin
 
@@ -85,7 +85,7 @@ GIVEN THAT I am on a screen with a webview
    - WHEN I have increased text size in device settings
       - THEN text resize is N/A for webview sections and native navigation bar text 
 
-Full information: [https://www.magentaa11y.com/#/native-criteria/patterns/webview](/native-criteria/patterns/webview)
+Full information: [https://www.magentaa11y.com/native-criteria/patterns/webview](/native-criteria/patterns/webview)
 
 ## iOS Developer Notes
 ### General Notes

--- a/public/content/documentation/web/component/alert-notification.md
+++ b/public/content/documentation/web/component/alert-notification.md
@@ -22,7 +22,7 @@ How to test an alert notification
    - Name: The alert is read when it appears (BUT focus DOES NOT transfer automatically when the alert appears)
    - Role: It identifies itself as an alert
 
-Full information: [https://www.magentaa11y.com/#/web-criteria/component/alert-notification](/web-criteria/component/alert-notification)
+Full information: [https://www.magentaa11y.com/web-criteria/component/alert-notification](/web-criteria/component/alert-notification)
 
 ## Gherkin
 
@@ -50,7 +50,7 @@ GIVEN THAT I am on a page with a alert notification
       - I HEAR the alert is read when it appears (BUT focus DOES NOT transfer automatically when the alert appears)
       - I HEAR it identifies itself as an alert
 
-Full information: [https://www.magentaa11y.com/#/web-criteria/component/alert-notification](/web-criteria/component/alert-notification)
+Full information: [https://www.magentaa11y.com/web-criteria/component/alert-notification](/web-criteria/component/alert-notification)
 
 ## Notes
 

--- a/public/content/documentation/web/component/animation.md
+++ b/public/content/documentation/web/component/animation.md
@@ -29,7 +29,7 @@ How to test an animation
 4. Device OS Settings
    - Reduced motion: Large motion, animations or effects are reduced or eliminated
 
-Full information: [https://www.magentaa11y.com/#/web-criteria/component/animation](/web-criteria/component/animation)
+Full information: [https://www.magentaa11y.com/web-criteria/component/animation](/web-criteria/component/animation)
 
 ## Gherkin
 
@@ -69,7 +69,7 @@ GIVEN THAT I am on a page with an animation
 
    - WHEN I use reduced motion THEN I see large motion, animations or effects are reduced or eliminated
 
-Full information: [https://www.magentaa11y.com/#/web-criteria/component/animation](/web-criteria/component/animation)
+Full information: [https://www.magentaa11y.com/web-criteria/component/animation](/web-criteria/component/animation)
 
 ## Developer Notes
 

--- a/public/content/documentation/web/component/autocomplete.md
+++ b/public/content/documentation/web/component/autocomplete.md
@@ -27,7 +27,7 @@ How to test an autocomplete input with listbox
    - Group: Its label is read and selected options are read
    - State: It indicates the value of the text input
      
-Full information: [https://www.magentaa11y.com/#/web-criteria/component/autocomplete](/web-criteria/component/autocomplete)
+Full information: [https://www.magentaa11y.com/web-criteria/component/autocomplete](/web-criteria/component/autocomplete)
 
 ## Gherkin
 
@@ -65,7 +65,7 @@ GIVEN THAT I am on a page with an autocomplete input with listbox
    - THEN when I doubletap with the select in focus I HEAR the selected option is changed
 
 
-Full information: [https://www.magentaa11y.com/#/web-criteria/component/autocomplete](/web-criteria/component/autocomplete)
+Full information: [https://www.magentaa11y.com/web-criteria/component/autocomplete](/web-criteria/component/autocomplete)
 
 ## Code Examples
 

--- a/public/content/documentation/web/component/button.md
+++ b/public/content/documentation/web/component/button.md
@@ -25,7 +25,7 @@ How to test a button
    - Group: It indicates if it has popup for listbox or menus
    - State: It expresses its state if applicable (pressed, expanded, disabled/dimmed/unavailable)
 
-Full information: [https://www.magentaa11y.com/#/web-criteria/component/button](/web-criteria/component/button)
+Full information: [https://www.magentaa11y.com/web-criteria/component/button](/web-criteria/component/button)
 
 ## Gherkin
 
@@ -59,7 +59,7 @@ GIVEN THAT I am on a page with a button
    - THEN when I doubletap with the button in focus I HEAR the intended action occurs
 
 
-Full information: [https://www.magentaa11y.com/#/web-criteria/component/button](/web-criteria/component/button)
+Full information: [https://www.magentaa11y.com/web-criteria/component/button](/web-criteria/component/button)
 
 ## Videos
 

--- a/public/content/documentation/web/component/carousel-slideshow.md
+++ b/public/content/documentation/web/component/carousel-slideshow.md
@@ -33,7 +33,7 @@ How to test a carousel/slideshow
 
 
 
-Full information: [https://www.magentaa11y.com/#/web-criteria/component/carousel-slideshow](/web-criteria/component/carousel-slideshow)
+Full information: [https://www.magentaa11y.com/web-criteria/component/carousel-slideshow](/web-criteria/component/carousel-slideshow)
 
 ## Gherkin
 
@@ -73,7 +73,7 @@ GIVEN THAT I am on a page with a carousel/slideshow
 
 
 
-Full information: [https://www.magentaa11y.com/#/web-criteria/component/carousel-slideshow](/web-criteria/component/carousel-slideshow)
+Full information: [https://www.magentaa11y.com/web-criteria/component/carousel-slideshow](/web-criteria/component/carousel-slideshow)
 
 ## Our General Advice
 

--- a/public/content/documentation/web/component/checkbox.md
+++ b/public/content/documentation/web/component/checkbox.md
@@ -25,7 +25,7 @@ How to test a checkbox
    - Group: Hints or errors are read after the label and related inputs include a group name (ex: Account settings)
    - State: It expresses its state (checked/unchecked, disabled)
 
-Full information: [https://www.magentaa11y.com/#/web-criteria/component/checkbox](/web-criteria/component/checkbox)
+Full information: [https://www.magentaa11y.com/web-criteria/component/checkbox](/web-criteria/component/checkbox)
 
 ## Gherkin
 
@@ -60,7 +60,7 @@ GIVEN THAT I am on a page with a checkbox
       - I HEAR it expresses its state (checked/unchecked, disabled)
    - THEN when I doubletap with the checkbox in focus I HEAR the state is changed
 
-Full information: [https://www.magentaa11y.com/#/web-criteria/component/checkbox](/web-criteria/component/checkbox)
+Full information: [https://www.magentaa11y.com/web-criteria/component/checkbox](/web-criteria/component/checkbox)
 
 ## Code examples
 

--- a/public/content/documentation/web/component/complex-graphics.md
+++ b/public/content/documentation/web/component/complex-graphics.md
@@ -28,7 +28,7 @@ How to test a figure, map, chart, and other complex graphics
 
    - Group: It typically contains the name and primary navigation of the website
 
-Full information: [https://www.magentaa11y.com/#/web-criteria/component/complex-graphics](/web-criteria/component/complex-graphics)
+Full information: [https://www.magentaa11y.com/web-criteria/component/complex-graphics](/web-criteria/component/complex-graphics)
 
 ## Gherkin
 
@@ -63,7 +63,7 @@ GIVEN THAT I am on a page with a header landmark
    - I HEAR It typically contains the name and primary navigation of the website
 
 
-Full information: [https://www.magentaa11y.com/#/web-criteria/component/complex-graphics](/web-criteria/component/complex-graphics)
+Full information: [https://www.magentaa11y.com/web-criteria/component/complex-graphics](/web-criteria/component/complex-graphics)
 
 ## Developer Notes
 

--- a/public/content/documentation/web/component/date-picker.md
+++ b/public/content/documentation/web/component/date-picker.md
@@ -30,7 +30,7 @@ How to test a date picker dialog
    - Group: The launch button indicates it has a popup, menu or dialog; days are announced with month and year
    - State: Date options express state (pressed, selected, disabled/dimmed)
 
-Full information: [https://www.magentaa11y.com/#/web-criteria/web/date-picker](/web-criteria/web/date-picker)
+Full information: [https://www.magentaa11y.com/web-criteria/web/date-picker](/web-criteria/web/date-picker)
 
 ## Gherkin
 
@@ -79,7 +79,7 @@ GIVEN THAT I am on a page with a date picker dialog
    - THEN when I swipe through the dialog I HEAR the date options and controls come into focus
    - THEN when I doubletap with the selection or button in focus I HEAR the intended action occurs
 
-Full information: [https://www.magentaa11y.com/#/web-criteria/web/date-picker](/web-criteria/web/date-picker)
+Full information: [https://www.magentaa11y.com/web-criteria/web/date-picker](/web-criteria/web/date-picker)
 
 ## Developer Notes
 

--- a/public/content/documentation/web/component/decorative-image.md
+++ b/public/content/documentation/web/component/decorative-image.md
@@ -17,7 +17,7 @@ How to test a decorative image
 3. Listen to screenreader output on all devices
     - Role: The image is ignored
 
-Full information: [https://www.magentaa11y.com/#/web-criteria/component/decorative-image](/web-criteria/component/decorative-image)
+Full information: [https://www.magentaa11y.com/web-criteria/component/decorative-image](/web-criteria/component/decorative-image)
 
 ## Gherkin
 
@@ -41,7 +41,7 @@ GIVEN THAT I am on a page with a decorative image
     - I swipe to browse to an image
       - I HEAR The image is ignored
 
-Full information: [https://www.magentaa11y.com/#/web-criteria/component/decorative-image](/web-criteria/component/decorative-image)
+Full information: [https://www.magentaa11y.com/web-criteria/component/decorative-image](/web-criteria/component/decorative-image)
 
 ## Decorative images
 
@@ -49,7 +49,7 @@ There are times that images shouldn't be read because it would be repetitive or 
 
 ## Is this image decorative or informative?
 
-If the image conveys important meaning, and there's no other text on the page which explains the concept within it, then the image is likely informative. In this case, check out the <a href="https://www.magentaa11y.com/#/web-criteria/component/informative-image">informative image checklist</a> item instead.
+If the image conveys important meaning, and there's no other text on the page which explains the concept within it, then the image is likely informative. In this case, check out the <a href="https://www.magentaa11y.com/web-criteria/component/informative-image">informative image checklist</a> item instead.
 
 ## Decorative images still require an alt attribute
 

--- a/public/content/documentation/web/component/expander-accordion.md
+++ b/public/content/documentation/web/component/expander-accordion.md
@@ -25,7 +25,7 @@ How to test an expander accordion
    - Role: It identifies its role of a button or details
    - State: It expresses its state (expanded/collapsed)
 
-Full information: [https://www.magentaa11y.com/#/web-criteria/component/expander-accordion](/web-criteria/component/expander-accordion)
+Full information: [https://www.magentaa11y.com/web-criteria/component/expander-accordion](/web-criteria/component/expander-accordion)
 
 ## Gherkin
 
@@ -58,7 +58,7 @@ GIVEN THAT I am on a page with an expander accordion
       - I HEAR it expresses its state (expanded/collapsed)
    - THEN when I doubletap with the button in focus I HEAR the intended action occurs
 
-Full information: [https://www.magentaa11y.com/#/web-criteria/component/expander-accordion](/web-criteria/component/expander-accordion)
+Full information: [https://www.magentaa11y.com/web-criteria/component/expander-accordion](/web-criteria/component/expander-accordion)
 
 ## Code examples
 

--- a/public/content/documentation/web/component/figure.md
+++ b/public/content/documentation/web/component/figure.md
@@ -23,7 +23,7 @@ How to test a figure: maps, charts, and graphics
    - Role: It identifies as a common HTML element (image, list, table)
    - Group: An alternative method of consumption or interaction is available
 
-Full information: [https://www.magentaa11y.com/#/web-criteria/component/figure](/web-criteria/component/figure)
+Full information: [https://www.magentaa11y.com/web-criteria/component/figure](/web-criteria/component/figure)
 
 ## Gherkin
 
@@ -56,7 +56,7 @@ GIVEN THAT I am on a page with a figure: maps, charts, and graphics
      - I HEAR an alternative method of consumption or interaction is available
 
 
-Full information: [https://www.magentaa11y.com/#/web-criteria/component/figure](/web-criteria/component/figure)
+Full information: [https://www.magentaa11y.com/web-criteria/component/figure](/web-criteria/component/figure)
 
 ## Developer Notes
 

--- a/public/content/documentation/web/component/footnote.md
+++ b/public/content/documentation/web/component/footnote.md
@@ -23,7 +23,7 @@ How to test a footnote
    - Name: It describes its purpose
    - Role: It identifies itself as a link
 
-Full information: [https://www.magentaa11y.com/#/web-criteria/component/footnote](/web-criteria/component/footnote)
+Full information: [https://www.magentaa11y.com/web-criteria/component/footnote](/web-criteria/component/footnote)
 
 ## Gherkin
 
@@ -54,7 +54,7 @@ GIVEN THAT I am on a page with a footnote
       - I HEAR it identifies itself as a link
    - THEN when I doubletap with the link in focus I HEAR my focus moves directly to the targeted footnote
 
-Full information: [https://www.magentaa11y.com/#/web-criteria/component/footnote](/web-criteria/component/footnote)
+Full information: [https://www.magentaa11y.com/web-criteria/component/footnote](/web-criteria/component/footnote)
 
 ## Developer Notes
 

--- a/public/content/documentation/web/component/heading.md
+++ b/public/content/documentation/web/component/heading.md
@@ -23,7 +23,7 @@ How to test a heading: h1, h2, h3, h4, h5, h6
       - Role: It identifies itself as a heading and its level
       - Group: It is logically ordered, starting with a single h1, sections titled by h2, and subsections with h3
 
-Full information: [https://www.magentaa11y.com/#/web-criteria/component/heading](/web-criteria/component/heading)
+Full information: [https://www.magentaa11y.com/web-criteria/component/heading](/web-criteria/component/heading)
 
 ## Gherkin
 
@@ -56,7 +56,7 @@ GIVEN THAT I am on a page with a heading
          - I HEAR it is logically ordered, starting with a single h1, sections titled by h2, and subsections with h3
 
 
-Full information: [https://www.magentaa11y.com/#/web-criteria/component/heading](/web-criteria/component/heading)
+Full information: [https://www.magentaa11y.com/web-criteria/component/heading](/web-criteria/component/heading)
 
 ## Headings are not focusable with the tab key
 

--- a/public/content/documentation/web/component/help-hint-error.md
+++ b/public/content/documentation/web/component/help-hint-error.md
@@ -21,7 +21,7 @@ How to test a hint, help, or error
    - Name: After the input name, the role and state is read. Then the hint, help, or error is read
    - Role: When it appears dynamically, an error is read automatically
 
-Full information: [https://www.magentaa11y.com/#/web-criteria/component/help-hint-error](/web-criteria/component/help-hint-error)
+Full information: [https://www.magentaa11y.com/web-criteria/component/help-hint-error](/web-criteria/component/help-hint-error)
 
 ## Gherkin
 
@@ -49,7 +49,7 @@ GIVEN THAT I am on a page with a hint, help, or error
       - I HEAR after the input name, the role and state is read, THEN the hint, help, or error is read
       - I HEAR when it appears dynamically, an error is read automatically
 
-Full information: [https://www.magentaa11y.com/#/web-criteria/component/help-hint-error](/web-criteria/component/help-hint-error)
+Full information: [https://www.magentaa11y.com/web-criteria/component/help-hint-error](/web-criteria/component/help-hint-error)
 
 ## Code examples
 

--- a/public/content/documentation/web/component/iframe.md
+++ b/public/content/documentation/web/component/iframe.md
@@ -22,7 +22,7 @@ How to test an iframe
    - Name: The title of the iframe is read if the iframe contains content 
    - Group: If the iframe does not contain content, the iframe is ignored
 
-Full information: [https://www.magentaa11y.com/#/web-criteria/component/iframe](/web-criteria/component/iframe)
+Full information: [https://www.magentaa11y.com/web-criteria/component/iframe](/web-criteria/component/iframe)
 
 ## Gherkin
 
@@ -49,7 +49,7 @@ GIVEN THAT I am on a page with an iframe
       - I HEAR if the iframe does not contain content, the iframe is ignored
 
 
-Full information: [https://www.magentaa11y.com/#/web-criteria/component/iframe](/web-criteria/component/iframe)
+Full information: [https://www.magentaa11y.com/web-criteria/component/iframe](/web-criteria/component/iframe)
 
 ## Code examples
 

--- a/public/content/documentation/web/component/informative-image.md
+++ b/public/content/documentation/web/component/informative-image.md
@@ -21,7 +21,7 @@ How to test an informative image
    - Name: The content of the image alt text is clear 
    - Role: It identifies its role as an image or graphic     
 
-Full information: [https://www.magentaa11y.com/#/web-criteria/component/informative-image](/web-criteria/component/informative-image)
+Full information: [https://www.magentaa11y.com/web-criteria/component/informative-image](/web-criteria/component/informative-image)
 
 ## Gherkin
 
@@ -49,11 +49,11 @@ GIVEN THAT I am on a page with an informative image
       - I HEAR the content of the image alt text is clear 
       - I HEAR it identifies its role as an image or graphic 
 
-Full information: [https://www.magentaa11y.com/#/web-criteria/component/informative-image](/web-criteria/component/informative-image)
+Full information: [https://www.magentaa11y.com/web-criteria/component/informative-image](/web-criteria/component/informative-image)
 
 ## Is this image decorative or informative?
 
-If the image conveys important meaning, and there's no other text on the page which explains the concept within it, then the image is likely informative. If the image is included for purely stylistic purposes and doesn't impart any meaning to the rest of the content on the page, then the image is likely decorative. In this case, check out the <a href="https://www.magentaa11y.com/#/web-criteria/component/decorative-image">decorative image checklist</a> item instead. 
+If the image conveys important meaning, and there's no other text on the page which explains the concept within it, then the image is likely informative. If the image is included for purely stylistic purposes and doesn't impart any meaning to the rest of the content on the page, then the image is likely decorative. In this case, check out the <a href="https://www.magentaa11y.com/web-criteria/component/decorative-image">decorative image checklist</a> item instead. 
 
 
 If your image contains text inside it, it should not! This is a violation of [WCAG AA 1.4.5 Images of Text](https://www.w3.org/WAI/WCAG21/Understanding/images-of-text.html). Exceptions exist for logos.

--- a/public/content/documentation/web/component/link.md
+++ b/public/content/documentation/web/component/link.md
@@ -24,7 +24,7 @@ How to test a link
    - Role: It identifies itself as a link
 
 
-Full information: [https://www.magentaa11y.com/#/web-criteria/component/link](/web-criteria/component/link)
+Full information: [https://www.magentaa11y.com/web-criteria/component/link](/web-criteria/component/link)
 
 ## Gherkin
 
@@ -56,7 +56,7 @@ GIVEN THAT I am on a page with a link
    - THEN when I doubletap with the link in focus I HEAR my browser goes somewhere
 
 
-Full information: [https://www.magentaa11y.com/#/web-criteria/component/link](/web-criteria/component/link)
+Full information: [https://www.magentaa11y.com/web-criteria/component/link](/web-criteria/component/link)
 
 
 ## Links vs buttons

--- a/public/content/documentation/web/component/list.md
+++ b/public/content/documentation/web/component/list.md
@@ -27,7 +27,7 @@ Test:
    - Role: It identifies itself as a list
    - Group: It declares the number of items in the list
 
-Full information: [https://www.magentaa11y.com/#/web-criteria/component/list](/web-criteria/component/list)
+Full information: [https://www.magentaa11y.com/web-criteria/component/list](/web-criteria/component/list)
 
 ## Gherkin
 
@@ -58,7 +58,7 @@ GIVEN THAT I am on a page with a list
       - I HEAR it identifies itself as a list
       - I HEAR it declares the number of items in the list
 
-Full information: [https://www.magentaa11y.com/#/web-criteria/component/list](/web-criteria/component/list)
+Full information: [https://www.magentaa11y.com/web-criteria/component/list](/web-criteria/component/list)
 
 ## Developer Notes
 

--- a/public/content/documentation/web/component/modal-dialog.md
+++ b/public/content/documentation/web/component/modal-dialog.md
@@ -29,7 +29,7 @@ How to test a modal dialog
    - Group: When closed, focus returns to the launch button.
    - State: When open, content behind the modal remains inert.
 
-Full information: [https://www.magentaa11y.com/#/web-criteria/component/modal-dialog](/web-criteria/component/modal-dialog)
+Full information: [https://www.magentaa11y.com/web-criteria/component/modal-dialog](/web-criteria/component/modal-dialog)
 
 ## Gherkin
 
@@ -73,7 +73,7 @@ GIVEN THAT I am on a page with a modal dialog
    - THEN when I swipe to move focus to the dismiss/close button AND THEN double tap on the close button I HEAR focus returns to the launch button
 
 
-Full information: [https://www.magentaa11y.com/#/web-criteria/component/modal-dialog](/web-criteria/component/modal-dialog)
+Full information: [https://www.magentaa11y.com/web-criteria/component/modal-dialog](/web-criteria/component/modal-dialog)
 
 ## Required attributes
 

--- a/public/content/documentation/web/component/number-input.md
+++ b/public/content/documentation/web/component/number-input.md
@@ -25,7 +25,7 @@ How to test a number input
    - Group: Hints or errors are read after the label, related inputs include a group name (Ex: Enter your personal information)
    - State: If applicable, it expresses its state (required, disabled / dimmed / unavailable)
 
-Full information: [https://www.magentaa11y.com/#/web-criteria/component/number-input](/web-criteria/component/number-input)
+Full information: [https://www.magentaa11y.com/web-criteria/component/number-input](/web-criteria/component/number-input)
 
 ## Gherkin
 
@@ -62,7 +62,7 @@ GIVEN THAT I am on a page with a number input field
       - I HEAR if applicable, it expresses its state (required, disabled / dimmed / unavailable)
    - THEN when I enter a number I HEAR the numeric keypad is revealed
 
-Full information: [https://www.magentaa11y.com/#/web-criteria/component/number-input](/web-criteria/component/number-input)
+Full information: [https://www.magentaa11y.com/web-criteria/component/number-input](/web-criteria/component/number-input)
 
 ## Code examples
 
@@ -203,7 +203,7 @@ Use `type=text` with `inputmode="numeric"` with an input pattern and JavaScript 
 ## Developer notes
 
 - [Why the GOV.UK Design System team changed the input type for numbers](https://technology.blog.gov.uk/2020/02/24/why-the-gov-uk-design-system-team-changed-the-input-type-for-numbers/)
-- <a href="https://www.magentaa11y.com/#/web-criteria/component/stepper-input">Stepper/counter input example</a>
+- <a href="https://www.magentaa11y.com/web-criteria/component/stepper-input">Stepper/counter input example</a>
 
 ### Name
 - Include `for="input-id` in each `<label>` label to associate it with the input

--- a/public/content/documentation/web/component/pagination-nav.md
+++ b/public/content/documentation/web/component/pagination-nav.md
@@ -22,7 +22,7 @@ How to test a pagination nav
    - Name: The pagination nav has a logical name ("pagination")
    - Role: The nav landmark is discoverable with screenreader shortcuts
 
-Full information: [https://www.magentaa11y.com/#/web-criteria/component/pagination-nav](/web-criteria/component/pagination-nav)
+Full information: [https://www.magentaa11y.com/web-criteria/component/pagination-nav](/web-criteria/component/pagination-nav)
 
 ## Gherkin
 
@@ -54,7 +54,7 @@ GIVEN THAT I am on a page with a pagination nav
    - THEN when I doubletap with the link in focus I HEAR my browser goes to the intended location
 
 
-Full information: [https://www.magentaa11y.com/#/web-criteria/component/pagination-nav](/web-criteria/component/pagination-nav)
+Full information: [https://www.magentaa11y.com/web-criteria/component/pagination-nav](/web-criteria/component/pagination-nav)
 
 ## Code examples
 

--- a/public/content/documentation/web/component/password-input.md
+++ b/public/content/documentation/web/component/password-input.md
@@ -22,7 +22,7 @@ How to test a password input
    - Group: Hints or errors are read after the label (Ex: Password formatting)
    - State: It expresses if the password is being shown and if applicable: required, disabled / dimmed / unavailable
 
-Full information: [https://www.magentaa11y.com/#/web-criteria/component/password-input](/web-criteria/component/password-input)
+Full information: [https://www.magentaa11y.com/web-criteria/component/password-input](/web-criteria/component/password-input)
 
 ## Gherkin
 
@@ -55,7 +55,7 @@ GIVEN THAT I am on a page with a password input
      - I HEAR it expresses if the password is being shown and if applicable: required, disabled / dimmed / unavailable
 
 
-Full information: [https://www.magentaa11y.com/#/web-criteria/component/password-input](/web-criteria/component/password-input)
+Full information: [https://www.magentaa11y.com/web-criteria/component/password-input](/web-criteria/component/password-input)
 
 ## Code Examples
 

--- a/public/content/documentation/web/component/progress-indicator.md
+++ b/public/content/documentation/web/component/progress-indicator.md
@@ -22,7 +22,7 @@ How to test a progress indicator
    - Role: It identifies itself as some kind of progress indicator
    - State: It expresses its current value if it dynamically changes
 
-Full information: [https://www.magentaa11y.com/#/web-criteria/component/progress-indicator](/web-criteria/component/progress-indicator)
+Full information: [https://www.magentaa11y.com/web-criteria/component/progress-indicator](/web-criteria/component/progress-indicator)
 
 ## Gherkin
 
@@ -52,7 +52,7 @@ GIVEN THAT I am on a page with a progress indicator
       - I HEAR it identifies itself as some kind of progress indicator
       - I HEAR it expresses its current value if it dynamically changes
 
-Full information: [https://www.magentaa11y.com/#/web-criteria/component/progress-indicator](/web-criteria/component/progress-indicator)
+Full information: [https://www.magentaa11y.com/web-criteria/component/progress-indicator](/web-criteria/component/progress-indicator)
 
 ## Developer Notes
 

--- a/public/content/documentation/web/component/radio-button.md
+++ b/public/content/documentation/web/component/radio-button.md
@@ -32,7 +32,7 @@ How to test a radio button
 
       - State: It expresses its state (selected, checked, disabled)
 
-Full information: [https://www.magentaa11y.com/#/web-criteria/form/radio-button](/web-criteria/form/radio-button)
+Full information: [https://www.magentaa11y.com/web-criteria/form/radio-button](/web-criteria/form/radio-button)
 
 ## Gherkin
 
@@ -77,7 +77,7 @@ GIVEN THAT I am on a page with a radio button
       - THEN when I doubletap with the radio in focus I HEAR the state is changed
 
 
-Full information: [https://www.magentaa11y.com/#/web-criteria/form/radio-button](/web-criteria/form/radio-button)
+Full information: [https://www.magentaa11y.com/web-criteria/form/radio-button](/web-criteria/form/radio-button)
 
 ## Code examples
 

--- a/public/content/documentation/web/component/range-slider.md
+++ b/public/content/documentation/web/component/range-slider.md
@@ -26,7 +26,7 @@ How to test a range slider input
    - Group: Its label is read with the input
    - State: Its current value
 
-Full information: [https://www.magentaa11y.com/#/web-criteria/component/range-slider](/web-criteria/component/range-slider)
+Full information: [https://www.magentaa11y.com/web-criteria/component/range-slider](/web-criteria/component/range-slider)
 
 ## Gherkin
 
@@ -61,7 +61,7 @@ GIVEN THAT I am on a page with a range slider input
       - I HEAR its current value
    - THEN when I swipe up/down in iOS or use the volume buttons in Android I HEAR the value is changed one step
 
-Full information: [https://www.magentaa11y.com/#/web-criteria/component/range-slider](/web-criteria/component/range-slider)
+Full information: [https://www.magentaa11y.com/web-criteria/component/range-slider](/web-criteria/component/range-slider)
 
 ## Code examples
 

--- a/public/content/documentation/web/component/scrolling-container.md
+++ b/public/content/documentation/web/component/scrolling-container.md
@@ -19,7 +19,7 @@ How to test a scrolling container
    - Name: Its purpose is clear
    - Role: It identifies its role as region
 
-Full information: [https://www.magentaa11y.com/#/web-criteria/scrolling](/web-criteria/scrolling)
+Full information: [https://www.magentaa11y.com/web-criteria/scrolling](/web-criteria/scrolling)
 
 ## Gherkin
 
@@ -46,7 +46,7 @@ GIVEN THAT I am on a page with a scrolling container
    - THEN when I swipe move browse to the content I HEAR the content is read
 
 
-Full information: [https://www.magentaa11y.com/#/web-criteria/scrolling](/web-criteria/scrolling)
+Full information: [https://www.magentaa11y.com/web-criteria/scrolling](/web-criteria/scrolling)
 
 ## Code Examples
 

--- a/public/content/documentation/web/component/search.md
+++ b/public/content/documentation/web/component/search.md
@@ -25,7 +25,7 @@ How to test a search input
    - Role: It identifies itself as a search input
    - Group: The form itself is discoverable with screenreader shortcuts as a search input
 
-Full information: [https://www.magentaa11y.com/#/web-criteria/component/search](/web-criteria/component/search)
+Full information: [https://www.magentaa11y.com/web-criteria/component/search](/web-criteria/component/search)
 
 ## Gherkin
 
@@ -60,7 +60,7 @@ GIVEN THAT I am on a page with a search input
       - I HEAR the form itself is discoverable with screenreader
 
 
-Full information: [https://www.magentaa11y.com/#/web-criteria/component/search](/web-criteria/component/search)
+Full information: [https://www.magentaa11y.com/web-criteria/component/search](/web-criteria/component/search)
 
 
 ## Videos
@@ -110,7 +110,7 @@ Full information: [https://www.magentaa11y.com/#/web-criteria/component/search](
 
 ### Search with autocomplete suggestions
 
-- For search autocomplete see <a href="https://www.magentaa11y.com/#/web-criteria/component/autocomplete">Autocomplete input with listbox</a>
+- For search autocomplete see <a href="https://www.magentaa11y.com/web-criteria/component/autocomplete">Autocomplete input with listbox</a>
 
 ```html
 <form role="search">

--- a/public/content/documentation/web/component/select-dropdown.md
+++ b/public/content/documentation/web/component/select-dropdown.md
@@ -74,7 +74,7 @@ How to test a select dropdown
 
       - State: It indicates which option is selected and if disabled/dimmed/unavailable
 
-Full information: [https://www.magentaa11y.com/#/web-criteria/component/select-dropdown](/web-criteria/component/select-dropdown)
+Full information: [https://www.magentaa11y.com/web-criteria/component/select-dropdown](/web-criteria/component/select-dropdown)
 
 ## Gherkin
 
@@ -118,7 +118,7 @@ GIVEN THAT I am on a page with a select dropdown
 
       - THEN when I doubletap with the select in focus I HEAR the options can be selected
 
-Full information: [https://www.magentaa11y.com/#/web-criteria/component/select-dropdown](/web-criteria/component/select-dropdown)
+Full information: [https://www.magentaa11y.com/web-criteria/component/select-dropdown](/web-criteria/component/select-dropdown)
 
 ## Code examples
 

--- a/public/content/documentation/web/component/separator-horizontal-rule.md
+++ b/public/content/documentation/web/component/separator-horizontal-rule.md
@@ -20,7 +20,7 @@ How to test a separator / horizontal rule
 
    - Name: The element is skipped entirely. It is completely inert.
 
-Full information: [https://www.magentaa11y.com/#/web-criteria/component/separator-horizontal-rule](/web-criteria/component/separator-horizontal-rule)
+Full information: [https://www.magentaa11y.com/web-criteria/component/separator-horizontal-rule](/web-criteria/component/separator-horizontal-rule)
 
 ## Gherkin
 
@@ -46,7 +46,7 @@ GIVEN THAT I am on a page with a separator / horizontal rule
    - I swipe to the separator
       - I HEAR the element is skipped entirely. It is completely inert.
 
-Full information: [https://www.magentaa11y.com/#/web-criteria/component/separator-horizontal-rule](/web-criteria/component/separator-horizontal-rule)
+Full information: [https://www.magentaa11y.com/web-criteria/component/separator-horizontal-rule](/web-criteria/component/separator-horizontal-rule)
 
 ## Developer notes
 

--- a/public/content/documentation/web/component/star-rating.md
+++ b/public/content/documentation/web/component/star-rating.md
@@ -26,7 +26,7 @@ How to test a star rating input
       - Group: Each option has an associated label and the radio group name
       - State: It expresses its state (selected, checked, disabled)
 
-Full information: [https://www.magentaa11y.com/#/web-criteria/component/star-rating](/web-criteria/component/star-rating)
+Full information: [https://www.magentaa11y.com/web-criteria/component/star-rating](/web-criteria/component/star-rating)
 
 ## Gherkin
 
@@ -64,7 +64,7 @@ GIVEN THAT I am on a star rating input
       - Then when I doubletap with the radio in focus I HEAR the state is changed
 
 
-Full information: [https://www.magentaa11y.com/#/web-criteria/component/star-rating](/web-criteria/component/star-rating)
+Full information: [https://www.magentaa11y.com/web-criteria/component/star-rating](/web-criteria/component/star-rating)
 
 
 

--- a/public/content/documentation/web/component/stepper-input.md
+++ b/public/content/documentation/web/component/stepper-input.md
@@ -32,7 +32,7 @@ How to test a stepper input
    - Group: Its label is read with the input.
    - State: It indicates when the select is expanded/collapsed, indicates which option is selected.
 
-Full information: [https://www.magentaa11y.com/#/web-criteria/component/stepper-input](/web-criteria/component/stepper-input)
+Full information: [https://www.magentaa11y.com/web-criteria/component/stepper-input](/web-criteria/component/stepper-input)
 
 ## Gherkin
 
@@ -71,7 +71,7 @@ GIVEN THAT I am on a page with a stepper input
    - THEN when I doubletap with the select in focus I HEAR the picker/spinner opens
    - THEN when I doubletap with the button in focus I HEAR the value is incremented or decremented
 
-Full information: [https://www.magentaa11y.com/#/web-criteria/component/stepper-input](/web-criteria/component/stepper-input)
+Full information: [https://www.magentaa11y.com/web-criteria/component/stepper-input](/web-criteria/component/stepper-input)
 
 ## Code examples
 

--- a/public/content/documentation/web/component/sticky-element.md
+++ b/public/content/documentation/web/component/sticky-element.md
@@ -21,7 +21,7 @@ How to test a sticky element
    - Group: Interactive elements are read in logical order in relation to the whole page
 
 
-Full information: [https://www.magentaa11y.com/#/web-criteria/component/sticky-element](/web-criteria/component/sticky-element)
+Full information: [https://www.magentaa11y.com/web-criteria/component/sticky-element](/web-criteria/component/sticky-element)
 
 ## Gherkin
 
@@ -50,7 +50,7 @@ GIVEN THAT I am on a page with a sticky element
       - I HEAR Interactive elements are read in logical order in relation to the whole page
 
 
-Full information: [https://www.magentaa11y.com/#/web-criteria/component/sticky-element](/web-criteria/component/sticky-element)
+Full information: [https://www.magentaa11y.com/web-criteria/component/sticky-element](/web-criteria/component/sticky-element)
 
 <!-- ## Developer Notes
 

--- a/public/content/documentation/web/component/strikethrough-content.md
+++ b/public/content/documentation/web/component/strikethrough-content.md
@@ -20,7 +20,7 @@ How to test a strikethrough element
 
       - Name: The content makes sense and is in a logical order
 
-Full information: [https://www.magentaa11y.com/#/web-criteria/component/strikethrough-content](/web-criteria/component/strikethrough-content)
+Full information: [https://www.magentaa11y.com/web-criteria/component/strikethrough-content](/web-criteria/component/strikethrough-content)
 
 ## Gherkin
 
@@ -46,7 +46,7 @@ GIVEN THAT I am on a page with strikethrough content
       - I swipe to browse the content
          - I HEAR the content makes sense and is in a logical order
 
-Full information: [https://www.magentaa11y.com/#/web-criteria/component/strikethrough-content](/web-criteria/component/strikethrough-content)
+Full information: [https://www.magentaa11y.com/web-criteria/component/strikethrough-content](/web-criteria/component/strikethrough-content)
 
 ## Developer notes
 

--- a/public/content/documentation/web/component/table.md
+++ b/public/content/documentation/web/component/table.md
@@ -22,7 +22,7 @@ How to test a table
    - Role: It identifies itself as a table
    - Group: Column headers and row headers are identified with screenreader shortcuts
 
-Full information: [https://www.magentaa11y.com/#/web-criteria/component/table](/web-criteria/component/table)
+Full information: [https://www.magentaa11y.com/web-criteria/component/table](/web-criteria/component/table)
 
 ## Gherkin
 
@@ -52,7 +52,7 @@ GIVEN THAT I am on a page with a table
       - I HEAR it identifies itself as a table
       - I HEAR column headers and row headers are identified with screenreader shortcuts
 
-Full information: [https://www.magentaa11y.com/#/web-criteria/component/table](/web-criteria/component/table)
+Full information: [https://www.magentaa11y.com/web-criteria/component/table](/web-criteria/component/table)
 
 ## Code examples
 ### Use semantic HTML

--- a/public/content/documentation/web/component/tabs.md
+++ b/public/content/documentation/web/component/tabs.md
@@ -32,7 +32,7 @@ How to test tabs
 
       - State: It expresses its state (selected/pressed/checked)
 
-Full information: [https://www.magentaa11y.com/#/web-criteria/component/tabs](/web-criteria/component/tabs)
+Full information: [https://www.magentaa11y.com/web-criteria/component/tabs](/web-criteria/component/tabs)
 
 ## Gherkin
 
@@ -80,7 +80,7 @@ GIVEN THAT I am on a page with tabs
 
 
 
-Full information: [https://www.magentaa11y.com/#/web-criteria/component/tabs](/web-criteria/component/tabs)
+Full information: [https://www.magentaa11y.com/web-criteria/component/tabs](/web-criteria/component/tabs)
 
 ## Tab groups
 

--- a/public/content/documentation/web/component/text-input.md
+++ b/public/content/documentation/web/component/text-input.md
@@ -24,7 +24,7 @@ How to test a text input
    - Group: Hints or errors are read after the label, related inputs include a group name (Ex: Enter your personal information)
    - State: If applicable, it expresses its state (required, disabled / dimmed / unavailable)
 
-Full information: [https://www.magentaa11y.com/#/web-criteria/component/text-input](/web-criteria/component/text-input)
+Full information: [https://www.magentaa11y.com/web-criteria/component/text-input](/web-criteria/component/text-input)
 
 ## Gherkin
 
@@ -56,7 +56,7 @@ GIVEN THAT I am on a page with a text input
       - I HEAR hints or errors are read after the label, related inputs include a group name (Ex: Enter your personal information)
       - I HEAR if applicable, it expresses its state (required, disabled / dimmed / unavailable)
 
-Full information: [https://www.magentaa11y.com/#/web-criteria/component/text-input](/web-criteria/component/text-input)
+Full information: [https://www.magentaa11y.com/web-criteria/component/text-input](/web-criteria/component/text-input)
 
 ## Code examples
 

--- a/public/content/documentation/web/component/textarea-multiline-input.md
+++ b/public/content/documentation/web/component/textarea-multiline-input.md
@@ -25,7 +25,7 @@ How to test a textarea multiline input
    - State: If applicable, it expresses its state (required, disabled / dimmed / unavailable)
    - Status: Character counter updates dynamically after keypress and a short delay
 
-Full information: [https://www.magentaa11y.com/#/web-criteria/component/textarea-multiline-input](/web-criteria/component/textarea-multiline-input)
+Full information: [https://www.magentaa11y.com/web-criteria/component/textarea-multiline-input](/web-criteria/component/textarea-multiline-input)
 
 ## Gherkin
 
@@ -58,7 +58,7 @@ GIVEN THAT I am on a page with a textarea multiline input
       - I HEAR Character counter updates dynamically after keypress and a short delay
 
 
-Full information: [https://www.magentaa11y.com/#/web-criteria/component/textarea-multiline-input](/web-criteria/component/textarea-multiline-input)
+Full information: [https://www.magentaa11y.com/web-criteria/component/textarea-multiline-input](/web-criteria/component/textarea-multiline-input)
 
 
 

--- a/public/content/documentation/web/component/tidbit.md
+++ b/public/content/documentation/web/component/tidbit.md
@@ -24,7 +24,7 @@ How to test a tidbit
    - Role: It identifies the info icon as an image and the Tidbit heading as a heading.
    - Group: There is no grouping for the Tidbit.
 
-Full information: [https://www.magentaa11y.com/#/web-criteria/component/tidbit](/web-criteria/component/tidbit)
+Full information: [https://www.magentaa11y.com/web-criteria/component/tidbit](/web-criteria/component/tidbit)
 
 ## Gherkin
 
@@ -58,7 +58,7 @@ GIVEN THAT I am on a page with a tidbit
       - I HEAR it identifies the info icon as an image and the Tidbit heading as a heading
       - I HEAR there is no grouping for the Tidbit
 
-Full information: [https://www.magentaa11y.com/#/web-criteria/component/tidbit](/web-criteria/component/tidbit)
+Full information: [https://www.magentaa11y.com/web-criteria/component/tidbit](/web-criteria/component/tidbit)
 
 ## Code examples
 

--- a/public/content/documentation/web/component/toast-snackbar.md
+++ b/public/content/documentation/web/component/toast-snackbar.md
@@ -26,7 +26,7 @@ How to test a toast snackbar
    - Group: If it is possible to close the toast, focus then returns to a logical place in the page
    - State: It remains open until closed by user
 
-Full information: [https://www.magentaa11y.com/#/web-criteria/component/toast-snackbar](/web-criteria/component/toast-snackbar)
+Full information: [https://www.magentaa11y.com/web-criteria/component/toast-snackbar](/web-criteria/component/toast-snackbar)
 
 ## Gherkin
 
@@ -58,7 +58,7 @@ GIVEN THAT I am on a page with a toast snackbar
       - I HEAR if it is possible to close the toast, focus then returns to a logical place in the page
       - I HEAR it remains open until closed by user
 
-Full information: [https://www.magentaa11y.com/#/web-criteria/component/toast-snackbar](/web-criteria/component/toast-snackbar)
+Full information: [https://www.magentaa11y.com/web-criteria/component/toast-snackbar](/web-criteria/component/toast-snackbar)
 
 ## Rethinking Toast Snackbars
 

--- a/public/content/documentation/web/component/toggle-switch.md
+++ b/public/content/documentation/web/component/toggle-switch.md
@@ -67,7 +67,7 @@ How to test a toggle switch
    - Group: Hints or errors are read after the label and related inputs include a group name (Ex: Account settings)
    - State: It expresses its state (on/off, checked/unchecked, disabled/dimmed)
 
-Full information: [https://www.magentaa11y.com/#/web-criteria/component/toggle-switch](/web-criteria/component/toggle-switch)
+Full information: [https://www.magentaa11y.com/web-criteria/component/toggle-switch](/web-criteria/component/toggle-switch)
 
 ## Gherkin
 
@@ -102,7 +102,7 @@ GIVEN THAT I am on a page with a toggle switch
       - I HEAR it expresses its state (on/off, checked/unchecked, disabled/dimmed)
    - THEN when I doubletap with the switch in focus I HEAR the state is changed
 
-Full information: [https://www.magentaa11y.com/#/web-criteria/component/toggle-switch](/web-criteria/component/toggle-switch)
+Full information: [https://www.magentaa11y.com/web-criteria/component/toggle-switch](/web-criteria/component/toggle-switch)
 
 ## Code examples
 

--- a/public/content/documentation/web/component/tooltip.md
+++ b/public/content/documentation/web/component/tooltip.md
@@ -26,7 +26,7 @@ How to test a tooltip
    - Tooltip: The tooltip content is read aloud (via `aria-describedby` or role="tooltip").
    - Action: It is clear whether the button performs an action or is static.
 
-Full information: [https://www.magentaa11y.com/#/web-criteria/component/tooltip](https://www.magentaa11y.com/#/web-criteria/component/tooltip)
+Full information: [https://www.magentaa11y.com/web-criteria/component/tooltip](https://www.magentaa11y.com/web-criteria/component/tooltip)
 
 ## Gherkin
 
@@ -65,7 +65,7 @@ GIVEN THAT I am on a page with a tooltip button
      I HEAR the intended action occurs (if applicable)
 
 
-Full information: [https://www.magentaa11y.com/#/web-criteria/component/tooltip](https://www.magentaa11y.com/#/web-criteria/component/tooltip)
+Full information: [https://www.magentaa11y.com/web-criteria/component/tooltip](https://www.magentaa11y.com/web-criteria/component/tooltip)
 
 ## Developer Notes
 

--- a/public/content/documentation/web/component/video-audio-player.md
+++ b/public/content/documentation/web/component/video-audio-player.md
@@ -27,7 +27,7 @@ How to test a video/audio player
    - Group: Audio content never autoplays
    - State: It expresses it state if applicable (pressed, expanded, disabled)
 
-Full information: [https://www.magentaa11y.com/#/web-criteria/component/video-audio-player](/web-criteria/component/video-audio-player)
+Full information: [https://www.magentaa11y.com/web-criteria/component/video-audio-player](/web-criteria/component/video-audio-player)
 
 ## Gherkin
 
@@ -70,7 +70,7 @@ GIVEN THAT I am on a page with a video/audio player
    - Then when I doubletap with the video control in focus I HEAR the intended action occurs
 
 
-Full information: [https://www.magentaa11y.com/#/web-criteria/component/video-audio-player](/web-criteria/component/video-audio-player)
+Full information: [https://www.magentaa11y.com/web-criteria/component/video-audio-player](/web-criteria/component/video-audio-player)
 
 ## Developer notes
 

--- a/public/content/documentation/web/page-level/basic-web-page.md
+++ b/public/content/documentation/web/page-level/basic-web-page.md
@@ -32,7 +32,7 @@ GIVEN THAT I am on a page with a basic web page
 4. Device OS settings
    - WHEN I use zoom/pinch THEN I see text can resize up to 200% without losing information
 
-Full information: https://www.magentaa11y.com/#/web-criteria/page-level/basic-web-page
+Full information: https://www.magentaa11y.com/web-criteria/page-level/basic-web-page
 
 ## Validate your code
 Use [HTML validation](https://validator.w3.org/nu/) as the foundation for ensuring your page works for everyone.
@@ -78,10 +78,10 @@ People with low vision need the ability to enlarge the page on mobile and deskto
 Landmarks give structure to the page for the screenreader user to be able to navigate the page by major sections.
 
 Each page must include:
-   - <a href="https://www.magentaa11y.com/#/web-criteria/page-level/header-landmark">Header</a>
-   - <a href="https://www.magentaa11y.com/#/web-criteria/page-level/navigation-landmark">Nav</a>
-   - <a href="https://www.magentaa11y.com/#/web-criteria/page-level/main-landmark">Main</a>
-   - <a href="https://www.magentaa11y.com/#/web-criteria/page-level/footer-landmark">Footer</a>
+   - <a href="https://www.magentaa11y.com/web-criteria/page-level/header-landmark">Header</a>
+   - <a href="https://www.magentaa11y.com/web-criteria/page-level/navigation-landmark">Nav</a>
+   - <a href="https://www.magentaa11y.com/web-criteria/page-level/main-landmark">Main</a>
+   - <a href="https://www.magentaa11y.com/web-criteria/page-level/footer-landmark">Footer</a>
 
 ```html
 <header>
@@ -124,4 +124,4 @@ How to test a basic web page
 
     - Zoom/pinch: text can resize up to 200% without losing information
 
-Full information: https://www.magentaa11y.com/#/web-criteria/page-level/basic-web-page
+Full information: https://www.magentaa11y.com/web-criteria/page-level/basic-web-page

--- a/public/content/documentation/web/page-level/footer-landmark.md
+++ b/public/content/documentation/web/page-level/footer-landmark.md
@@ -20,7 +20,7 @@ How to test a footer landmark
    - Role: It is discoverable with screenreader shortcuts as a footer or contentinfo landmark
    - Group: It typically contains copyright information, navigation links, and privacy statements.
 
-Full information: [https://www.magentaa11y.com/#/web-criteria/page-level/footer](/web-criteria/page-level/footer)
+Full information: [https://www.magentaa11y.com/web-criteria/page-level/footer](/web-criteria/page-level/footer)
 
 ## Gherkin
 
@@ -46,7 +46,7 @@ GIVEN THAT I am on a page with a footer landmark
       - I HEAR It typically contains copyright information, navigation links, and privacy statements.
 
 
-Full information: [https://www.magentaa11y.com/#/web-criteria/page-level/footer](/web-criteria/page-level/footer)
+Full information: [https://www.magentaa11y.com/web-criteria/page-level/footer](/web-criteria/page-level/footer)
 
 ## Code examples
 

--- a/public/content/documentation/web/page-level/form.md
+++ b/public/content/documentation/web/page-level/form.md
@@ -24,7 +24,7 @@ How to test a web form
    - Instructions: Presented before the form or inline, announced in order.
    - Errors: Errors are announced when inputs are invalid.
 
-Full information: [https://www.magentaa11y.com/#/web-criteria/page-level/form](/web-criteria/page-level/form)
+Full information: [https://www.magentaa11y.com/web-criteria/page-level/form](/web-criteria/page-level/form)
 
 ## Gherkin
 
@@ -53,7 +53,7 @@ GIVEN THAT I am on a page with a web form
      - I HEAR It is discoverable with screenreader shortcuts as a form landmark along with its name
      - I HEAR the screenreader switch from browse shortcuts to forms shortcuts
 
-Full information: [https://www.magentaa11y.com/#/web-criteria/page-level/form](/web-criteria/page-level/form)
+Full information: [https://www.magentaa11y.com/web-criteria/page-level/form](/web-criteria/page-level/form)
 
 ## Building accessible forms
 
@@ -70,8 +70,8 @@ Use `fieldset` and `legend` to group related fields, such as:
 
 ### Error handling
 
-- Individual inputs must have <a href="https://www.magentaa11y.com/#/web-criteria/component/help-hint-error">programmatically described errors</a> read by the screen reader on focus.
-- For long forms, list all errors in an <a href="https://www.magentaa11y.com/#/web-criteria/component/alert-notification">alert</a> with links back to each invalid input on submission attempts.
+- Individual inputs must have <a href="https://www.magentaa11y.com/web-criteria/component/help-hint-error">programmatically described errors</a> read by the screen reader on focus.
+- For long forms, list all errors in an <a href="https://www.magentaa11y.com/web-criteria/component/alert-notification">alert</a> with links back to each invalid input on submission attempts.
 
 ## UX guidance
 

--- a/public/content/documentation/web/page-level/header-landmark.md
+++ b/public/content/documentation/web/page-level/header-landmark.md
@@ -21,7 +21,7 @@ How to test a header landmark
    - Role: It is discoverable with screenreader shortcuts as header/banner landmark
    - Group: It typically contains the name and primary navigation of the website
 
-Full information: https://www.magentaa11y.com/#/web-criteria/page-level/header-landmark
+Full information: https://www.magentaa11y.com/web-criteria/page-level/header-landmark
 
 ## Gherkin
 
@@ -45,7 +45,7 @@ GIVEN THAT I am on a page with a header landmark
        - I HEAR It is discoverable with screenreader shortcuts as header/banner landmark
        - I HEAR It typically contains the name and primary navigation of the website
 
-Full information: https://www.magentaa11y.com/#/web-criteria/page-level/header-landmark
+Full information: https://www.magentaa11y.com/web-criteria/page-level/header-landmark
 
 ## General
 * There must only be a singular header/banner element on the page. 

--- a/public/content/documentation/web/page-level/main-landmark.md
+++ b/public/content/documentation/web/page-level/main-landmark.md
@@ -22,7 +22,7 @@ How to test a main landmark
    - Role: It is discoverable with screenreader shortcuts as main landmark
    - Group: It contains the content portion of the page starting with the H1
 
-Full information: [https://www.magentaa11y.com/#/web-criteria/page-level/main-landmark](/web-criteria/page-level/main-landmark)
+Full information: [https://www.magentaa11y.com/web-criteria/page-level/main-landmark](/web-criteria/page-level/main-landmark)
 
 ## Gherkin
 
@@ -52,7 +52,7 @@ GIVEN THAT I am on a page with a main landmark
       - I HEAR It contains the content portion of the page starting with the H1
 
 
-Full information: [https://www.magentaa11y.com/#/web-criteria/page-level/main-landmark](/web-criteria/page-level/main-landmark)
+Full information: [https://www.magentaa11y.com/web-criteria/page-level/main-landmark](/web-criteria/page-level/main-landmark)
 
 ## Code examples
 

--- a/public/content/documentation/web/page-level/navigation-landmark.md
+++ b/public/content/documentation/web/page-level/navigation-landmark.md
@@ -19,7 +19,7 @@ How to test a navigation landmark
    - **Name**: It indicates its role AND IF multiple navigations are present (ex: Main navigation, Site map, Breadcrumbs), the name of the navigation
    - **Role**: It is discoverable with screenreader shortcuts as a navigation landmark
 
-Full information: https://www.magentaa11y.com/#/web-criteria/page-level/navigation-landmark
+Full information: https://www.magentaa11y.com/web-criteria/page-level/navigation-landmark
 
 ## Gherkin
 
@@ -44,7 +44,7 @@ GIVEN THAT I am on a page with a navigation landmark
      - I HEAR It indicates its role AND IF multiple navigations are present (ex: Main navigation, Site map, Breadcrumbs), the name of the navigation
      - I HEAR It is discoverable with screenreader shortcuts as a navigation landmark.
 
-Full information: https://www.magentaa11y.com/#/web-criteria/page-level/navigation-landmark
+Full information: https://www.magentaa11y.com/web-criteria/page-level/navigation-landmark
 
 ## Code Examples
 

--- a/public/content/documentation/web/page-level/single-page-application.md
+++ b/public/content/documentation/web/page-level/single-page-application.md
@@ -22,7 +22,7 @@ How to test a single page application (SPA)
    - Name: New content is announced or indicated 
    - Group: Browsing and focus starts consistently at top of new page content or top of page
 
-Full information: [https://www.magentaa11y.com/#/web-criteria/component/single-page-application](/web-criteria/component/single-page-application)
+Full information: [https://www.magentaa11y.com/web-criteria/component/single-page-application](/web-criteria/component/single-page-application)
 
 ## Gherkin
 
@@ -52,7 +52,7 @@ GIVEN THAT I am on a page built with a SPA:
       - I HEAR new content is announced or indicated 
       - I HEAR browsing and focus starts consistently at top of new page content or top of page
 
-Full information: [https://www.magentaa11y.com/#/web-criteria/component/single-page-application](/web-criteria/component/single-page-application)
+Full information: [https://www.magentaa11y.com/web-criteria/component/single-page-application](/web-criteria/component/single-page-application)
 
 ## Focus management & consistency
 

--- a/public/content/documentation/web/page-level/skip-link.md
+++ b/public/content/documentation/web/page-level/skip-link.md
@@ -25,7 +25,7 @@ How to test a skip link
    - Group: It is typically the first element in the page
 
 
-Full information: [https://www.magentaa11y.com/#/web-criteria/page-level/skip-link](/web-criteria/page-level/skip-link)
+Full information: [https://www.magentaa11y.com/web-criteria/page-level/skip-link](/web-criteria/page-level/skip-link)
 
 ## Gherkin
 
@@ -60,7 +60,7 @@ GIVEN THAT I am on a page with a skip link
    - THEN when I doubletap with the link in focus I HEAR my focus moves directly to the targeted element
 
 
-Full information: [https://www.magentaa11y.com/#/web-criteria/page-level/skip-link](/web-criteria/page-level/skip-link)
+Full information: [https://www.magentaa11y.com/web-criteria/page-level/skip-link](/web-criteria/page-level/skip-link)
 
 ## Code examples
 

--- a/public/index.html
+++ b/public/index.html
@@ -16,7 +16,10 @@
     <meta property="og:image" content="%PUBLIC_URL%/app-assets/MagentaA11ySEOCard.svg">
     <meta property="og:image:width" content="1200" >
     <meta property="og:image:height" content="630" >
-    <meta property="og:url" content="https://magentaa11y.com/">
+    <meta property="og:url" content="https://www.magentaa11y.com/">
+    <!-- Fallback canonical. usePageTitle overwrites this per route on load;
+         this value is what a crawler sees if JavaScript does not run. -->
+    <link rel="canonical" href="https://www.magentaa11y.com/" />
     <meta property="og:image:alt" content="MagentaA11y by T-Mobile" >
     <meta property="og:description" content="An innovative open-source tool empowering product teams to master the craft of creating accessible digital experiences for all.">
     <meta name="publisher" content="T-Mobile Accessibility Resource Center">
@@ -24,11 +27,44 @@
     <meta name="twitter:image:alt" content="MagentaA11y by T-Mobile">
         <meta name="twitter:image" content="%PUBLIC_URL%/app-assets/MagentaA11ySEOCard.svg">
 
+    <!--
+      Routing support scripts. Both run before the app bundle and before
+      analytics, so the URL is correct by the time anything reads it.
+      Order matters: decoder first, then the legacy hash shim.
+    -->
     <script>
-      if (!window.location.hash && window.location.pathname !== '/') {
-        let path = window.location.pathname;
-        window.location.replace(window.location.origin + '/#' + path);
-      }
+      // 1. Decodes the ?/ path written by 404.html and restores the real URL.
+      //    See https://github.com/rafgraph/spa-github-pages
+      (function () {
+        try {
+          var l = window.location;
+          if (l.search[1] === '/') {
+            var decoded = l.search.slice(1).split('&').map(function (s) {
+              return s.replace(/~and~/g, '&');
+            }).join('?');
+            window.history.replaceState(null, null,
+              l.pathname.slice(0, -1) + decoded + l.hash);
+          }
+        } catch (e) {
+          /* Never block boot. */
+        }
+      })();
+
+      // 2. Rescues legacy hash URLs already in circulation:
+      //    /#/web-criteria/component/button -> /web-criteria/component/button
+      (function () {
+        try {
+          var h = window.location.hash;
+          if (h.indexOf('#/') !== 0) return; // leave real #anchors alone
+          var rest = h.slice(1);
+          var parts = rest.split('?');
+          var path = parts[0];
+          var query = parts[1] ? '?' + parts[1] : window.location.search;
+          window.history.replaceState(null, null, path + query);
+        } catch (e) {
+          /* Never block boot. */
+        }
+      })();
     </script>
 
     <script
@@ -50,7 +86,6 @@
       name="apple-mobile-web-app-status-bar-style"
       content="black-translucent" />
     <meta name="apple-mobile-web-app-title" content="MagentaA11y" />
-    <meta property="og:title" content="" />
 
     <!-- Apple Touch Icon -->
     <link

--- a/serve-pages.js
+++ b/serve-pages.js
@@ -1,0 +1,78 @@
+/*
+  Local server that mimics GitHub Pages.
+
+  The one rule that matters: if the requested path is not a real file on disk,
+  serve 404.html with a 404 status. That is the behaviour the routing fix
+  depends on, and it is why `npm start` cannot be used to test this. The dev
+  server compiles in memory and never serves 404.html at all.
+
+  Usage:
+    npm run build
+    node serve-pages.js
+    (or PORT=3001 node serve-pages.js if 3000 is taken)
+
+  This file is for local testing only. Do not reference it from the app.
+*/
+import http from 'node:http';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.join(__dirname, 'build');
+const PORT = process.env.PORT || 3000;
+
+const TYPES = {
+  '.html': 'text/html',
+  '.js': 'text/javascript',
+  '.css': 'text/css',
+  '.json': 'application/json',
+  '.svg': 'image/svg+xml',
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.webp': 'image/webp',
+  '.webm': 'video/webm',
+  '.mp4': 'video/mp4',
+  '.woff': 'font/woff',
+  '.woff2': 'font/woff2',
+  '.ico': 'image/x-icon',
+  '.txt': 'text/plain',
+};
+
+if (!fs.existsSync(ROOT)) {
+  console.error('No build folder found. Run "npm run build" first.');
+  process.exit(1);
+}
+
+http
+  .createServer((req, res) => {
+    const url = decodeURIComponent(req.url.split('?')[0].split('#')[0]);
+    let file = path.join(ROOT, url);
+
+    // Block path traversal
+    if (!file.startsWith(ROOT)) {
+      res.writeHead(403);
+      return res.end('Forbidden');
+    }
+
+    if (fs.existsSync(file) && fs.statSync(file).isDirectory()) {
+      file = path.join(file, 'index.html');
+    }
+
+    if (fs.existsSync(file) && fs.statSync(file).isFile()) {
+      res.writeHead(200, {
+        'Content-Type': TYPES[path.extname(file)] || 'application/octet-stream',
+      });
+      return fs.createReadStream(file).pipe(res);
+    }
+
+    // Not a real file, so serve 404.html the way GitHub Pages does
+    res.writeHead(404, { 'Content-Type': 'text/html' });
+    fs.createReadStream(path.join(ROOT, '404.html')).pipe(res);
+  })
+  .listen(PORT, () => {
+    console.log(`Serving ./build like GitHub Pages at http://localhost:${PORT}`);
+    console.log('Deep links return 404 and fall back to 404.html, as they do in production.');
+    console.log('Press Ctrl+C to stop.');
+  });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,7 @@
 import PageLayout from "components/page-layout/page-layout";
 import RedirectHandler from "components/redirect-handler/redirect-handler";
 import React from "react";
-import { HashRouter as Router } from "react-router-dom";
+import { BrowserRouter as Router } from "react-router-dom";
 
 import "./App.scss";
 

--- a/src/components/content-display/markdown-content/elements/markdown-link/markdown-link.tsx
+++ b/src/components/content-display/markdown-content/elements/markdown-link/markdown-link.tsx
@@ -23,7 +23,10 @@ const isExternalUrl = (href: string): boolean => {
  * Handles clicks on internal anchor links by scrolling to and focusing the target element.
  */
 const handleInternalAnchorClick = (e: React.MouseEvent, href: string) => {
-  e.preventDefault();
+  // The browser handles the jump and writes the fragment to the address bar,
+  // which is what makes these links shareable. We only add focus management,
+  // because browsers scroll to an anchor but do not reliably move keyboard
+  // and screen reader focus there.
   const targetId = href.substring(1);
   const targetElement = document.getElementById(targetId);
   if (targetElement) {

--- a/src/hooks/usePageTitle.ts
+++ b/src/hooks/usePageTitle.ts
@@ -1,6 +1,10 @@
 import { useEffect } from 'react';
 import { useLocation } from 'react-router-dom';
 
+// Must match public/CNAME exactly, including the www subdomain. A mismatch
+// here recreates the duplicate-hostname problem the canonical tag prevents.
+const SITE_ORIGIN = 'https://www.magentaa11y.com';
+
 export const usePageTitle = () => {
   const location = useLocation();
 
@@ -38,6 +42,30 @@ export const usePageTitle = () => {
     const ogTitleMeta = document.querySelector('meta[property="og:title"]');
     if (ogTitleMeta) {
       ogTitleMeta.setAttribute('content', pageTitle);
+    }
+
+    // Canonical URL for the current route.
+    // pathname only: the query string is deliberately excluded, because
+    // ?tab=1 is a view of the same page rather than a separate page. Including
+    // it would signal that every tab is its own page and split the ranking.
+    const canonicalHref = SITE_ORIGIN + location.pathname;
+
+    let canonicalLink = document.querySelector<HTMLLinkElement>(
+      'link[rel="canonical"]'
+    );
+
+    if (!canonicalLink) {
+      canonicalLink = document.createElement('link');
+      canonicalLink.setAttribute('rel', 'canonical');
+      document.head.appendChild(canonicalLink);
+    }
+
+    canonicalLink.setAttribute('href', canonicalHref);
+
+    // Keep og:url in step with the page being viewed
+    const ogUrlMeta = document.querySelector('meta[property="og:url"]');
+    if (ogUrlMeta) {
+      ogUrlMeta.setAttribute('content', canonicalHref);
     }
   }, [location]);
 };

--- a/src/scripts/createMarkdown.sh
+++ b/src/scripts/createMarkdown.sh
@@ -42,7 +42,7 @@ esac
 
 # Generate dynamic URL path
 SLUG_PATH=$(echo "$RELATIVE_PATH/$1" | sed "s|^$SECTION/||" | sed 's|/|/|g')
-FULL_LINK="https://www.magentaa11y.com/#/${CRITERIA_PREFIX}/${SLUG_PATH}"
+FULL_LINK="https://www.magentaa11y.com/${CRITERIA_PREFIX}/${SLUG_PATH}"
 
 # Check if the directory exists, if not create it
 if [ ! -d "$FULL_PATH" ]; then


### PR DESCRIPTION
- Swap HashRouter for BrowserRouter
- Remove hash rewrite script from index.html
- Add SPA fallback: 404.html encoder plus index.html decoder
- Add shim to rescue legacy /#/ links already in circulation
- Remove preventDefault from markdown-link so anchors are shareable
- Correct og:url to www hostname, remove duplicate empty og:title
- Add per-route canonical tags in usePageTitle
- Strip hash URLs from 93 criteria markdown files
- Fix createMarkdown.sh template so new content stays clean
- Add local routing test tools: serve-pages.js, check-routes.js

Verified locally: build compiles, 217/217 routes pass, 15 test suites pass.